### PR TITLE
docs: revise roadmap for Vite replatform + engine refactor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,126 +4,137 @@ Goal: take the current prototype (playable core loop, live at cryptofrenzy.live)
 releasable **v1.0 webapp**, then a **downloadable desktop build** via the existing Tauri
 scaffold, then optional retention features (leaderboards, daily runs).
 
-## Where the game stands today
+## Where the game stands (post [PR #31](https://github.com/whcarter3/crypto-frenzy/pull/31))
 
 **Working:** core trade loop (buy max / sell all), 5 coins with low/mid/high/moon price
-bands, compounding debt, wallet capacity upgrades, event flavor text, per-mode high
-scores in localStorage, Cypress E2E suite running in GitHub Actions, static export
-deployed on Vercel, Tauri 2 scaffold that builds.
+bands, compounding debt, wallet capacity upgrades, event flavor text, difficulty modes
+(Easy/Normal/Hard), run persistence with resume-or-new from the landing page, a real
+game-over screen with run stats, per-mode high scores, Cypress E2E suite (8 tests) in
+GitHub Actions, static export deployed on Vercel, Tauri 2 scaffold that builds.
 
-**Missing or broken (found in code):**
+**Known debt / still missing:**
 
-- **No run persistence** — a page refresh loses the entire run. Landing page says
-  "Persistence module: WIP".
-- **No real game-over screen** — `advanceDay` dispatches `TOGGLE_MODAL` at game end, but
-  the `GameMode` modal is commented out of `pages/game.tsx`, so the run just… stops,
-  with only a toast notification.
-- **Difficulty modes are dark-launched** — Easy/Hard logic is fully implemented in
-  `lib/reducer.ts` but the selector modal is commented out; Normal only.
-- **Buy is all-in only, sell is all-out only** — `lib/buySell.ts` always buys
-  `calculateMaxShares` and sells the full position. No quantity control.
-- **No settings, no sound, no help/tutorial** — all stubbed "SOON" on the landing page.
+- **Next.js platform mismatch** — a server-first framework wrapped around a game with
+  no server. Prerendering forces the hydration dance in `pages/game.tsx` (the
+  `hydrated` flag, restore-in-effect, modal-flash gating), the pages router is aging
+  with a CVE-upgrade treadmill (see the pile of Snyk PRs), and CI already tripped once
+  on static-export vs `next start`. Decision: **migrate to Vite** (Phase 1b).
+- **Game logic is split across dispatch helpers and the reducer** — `advanceDay` fires
+  8+ actions per day tick, which is why stats tracking needed the `trackPeakNetWorth`
+  wrapper flagged in PR #31 review. Decision: **reducer-as-game-engine refactor**
+  (Phase 1b).
+- **All randomness is bare `Math.random()`** — blocks seeded/daily runs, replay
+  verification, and deterministic tests. Folded into the engine refactor.
+- **Buy is all-in only, sell is all-out only** (`lib/buySell.ts`) — no quantity control.
+- **No settings, no sound, no in-game help** — stubbed "SOON" on the landing page.
 - **Mobile layout is broken** — `/game` uses fixed `w-1/4` / `w-1/2` panels.
-- **Identity crisis** — `package.json` name `crypto-wars` v0.9.0, Tauri product
-  `crypto-wars` v0.1.0 titled "Crypto Wars", site branded "Crypto Frenzy", landing page
-  hardcodes "BUILD 0.1.0".
-- **Tauri config is unshippable as-is** — identifier is `com.tauri.dev` (signing/stores
-  require a real one), default icons, `fullscreen: true`.
-- **Housekeeping** — README is create-next-app boilerplate; `cypress` is in
-  `dependencies` instead of `devDependencies`; `eslint-config-next` is v12 against
-  Next 13; no LICENSE; leftover `public/vercel.svg`; no unit tests (E2E only); all
-  randomness is bare `Math.random()` (blocks seeded/daily runs and deterministic tests).
+- **No unit tests** — E2E only; the money math deserves fast tests (unlocked by the
+  engine refactor).
+- **Tauri scaffold half-configured** — identifier and product name are fixed, but
+  default icons, `fullscreen: true`, and no release pipeline remain (Phase 3).
 
 ---
 
-## Phase 0 — Housekeeping ✅ (done)
+## Phase 0 — Housekeeping ✅ (shipped in PR #31)
 
-Cheap, do-first cleanup so everything after sits on a clean base.
+- [x] One name everywhere: **Crypto Frenzy** (`package.json`, `tauri.conf.json`
+      productName + window title, landing page). Tauri `identifier` fixed
+      (`live.cryptofrenzy.app`) ahead of Phase 3.
+- [x] Single version source: landing page reads `package.json` via
+      `NEXT_PUBLIC_APP_VERSION`; Tauri via `"version": "../package.json"`.
+- [x] `cypress` → `devDependencies`; `eslint-config-next` aligned; `root: true`.
+- [x] README rewritten; MIT LICENSE; `vercel.svg` removed; favicon.ico + favicon.svg.
 
-- [x] Pick the name (**Crypto Frenzy**) and apply it everywhere:
-      `package.json`, `tauri.conf.json` (`productName`, window title), landing page.
-      Also fixed the Tauri `identifier` (`live.cryptofrenzy.app`) ahead of Phase 3.
-- [x] Single source of truth for version; the landing page reads it from
-      `package.json` via `NEXT_PUBLIC_APP_VERSION`, Tauri via `"version": "../package.json"`.
-- [x] Move `cypress` to `devDependencies`; align `eslint-config-next` with Next 13.
-- [x] Rewrite README for the actual game (what it is, how to run, how to test).
-- [x] Add LICENSE; remove `public/vercel.svg`; favicon.ico + favicon.svg.
+## Phase 1a — Persistence & run lifecycle ✅ (shipped in PR #31)
 
-## Phase 1 — Core game completeness (the real table stakes)
+- [x] Versioned localStorage autosave (`lib/state/persistence.ts`); restore on load;
+      "Resume run / New run" on the landing page.
+- [x] Real game-over screen with final score, high-score callout, and run stats
+      (`components/GameOver.tsx`). Fixed along the way: game over previously never
+      fired, and a losing run could clobber the saved high score.
+- [x] Difficulty modal re-enabled with a cleaned-up start flow.
 
-This is the bulk of the work. Everything here applies to both web and desktop.
+## Phase 1b — Replatform (NEXT UP)
 
-**1a. Persistence & run lifecycle ✅ (done)**
-- [x] Auto-save game state to localStorage on every state change
-      (`lib/state/persistence.ts`, versioned save file).
-- [x] Restore on load; "Resume run / New run" choice on the landing page.
-- [x] Real **game-over screen**: final score, run stats (best trade, peak net worth,
-      trades made), high-score callout, "Play again" / difficulty select
-      (`components/GameOver.tsx`). Also fixed: game over previously never fired
-      (the Adv Day button disabled itself on the final day), and finishing a run
-      with a lower score used to overwrite the saved high score.
-- [x] Re-enable the difficulty modal (start flow cleaned up in `GameMode.tsx`).
+Swap the foundation before stacking more features on it. Two PRs, in this order:
 
-**1b. Trading UX**
-- [ ] Quantity controls for buy/sell (input + Max button) instead of forced all-in/all-out.
+**Vite migration** — replace Next.js with Vite + React SPA.
+- [ ] Port `pages/` to routes (react-router or equivalent); `next/head` → document
+      titles; `next/link` → router links. `lib/` and components are already
+      framework-free and should move untouched.
+- [ ] Read the save **synchronously** in the `useReducer` lazy initializer — no
+      prerender means no hydration mismatch. Delete the `hydrated` flag, the
+      restore-in-effect, and the modal-flash gating (resolves PR #31 review comments).
+- [ ] Version string via Vite `define`/`import.meta.env` (replaces
+      `NEXT_PUBLIC_APP_VERSION`).
+- [ ] Update CI (`vite build`, serve `dist/`) and Tauri config
+      (`frontendDist`, `devUrl`, beforeDev/BuildCommand).
+- [ ] Known tradeoff: landing page loses prerendered HTML (minor SEO hit).
+      Mitigate later with a prerender plugin for the landing route if it matters.
+- [ ] E2E suite green before and after — it's the migration safety net.
+
+**Engine refactor** — make the reducer the actual game engine.
+- [ ] One player intent = one action: `ADVANCE_DAY` computes the entire day transition
+      (prices, events, debt, logs) inside the reducer; kill multi-dispatch helpers.
+- [ ] Injectable, seedable RNG threaded through the engine — unlocks daily challenges,
+      replay verification, and deterministic tests.
+- [ ] Run stats tracked inside transitions — removes the `trackPeakNetWorth` wrapper.
+- [ ] Unit tests for the economy: reducer transitions, cost-basis math, debt
+      compounding, price banding.
+
+## Phase 1c — Trading UX
+
+- [ ] Quantity controls for buy/sell (input + Max button) instead of forced
+      all-in/all-out.
 - [ ] Confirm/feedback affordances: disable states that explain themselves, tooltips.
 - [ ] Optional could-have: partial debt payments (currently pay-in-full only).
 
-**1c. Presentation & feel**
+## Phase 1d — Presentation & feel
+
 - [ ] Sound effects (buy, sell, day tick, moonshot, game over) + music toggle; mute
-      persisted in settings. Web Audio or howler.
+      persisted in settings.
 - [ ] Settings panel: sound, **CRT effects toggle** (scanline flicker is an
       accessibility issue — also respect `prefers-reduced-motion`), reset high scores.
 - [ ] In-game "How to play" (the landing page copy is 80% of it already).
-- [ ] Responsive pass so `/game` works on phones/tablets (or an explicit
-      desktop-only gate for v1 — decision below).
+- [ ] Responsive pass so `/game` works on phones/tablets.
 - [ ] Accessibility pass: keyboard navigation, `aria-live` on the event log, don't
       rely on color alone for profit/loss.
 
-**1d. Engineering hardening**
-- [ ] Extract randomness behind a seedable RNG (one injection point). Enables unit
-      tests now, daily-challenge/replay verification later.
-- [ ] Unit tests for the economy: reducer actions, cost-basis math, debt compounding,
-      price banding. (Cypress covers flows; the money math deserves fast tests.)
-- [ ] Keep the E2E suite green through all of the above.
-
 ## Phase 2 — Web release (v1.0 on cryptofrenzy.live)
 
-- [ ] **PWA**: manifest + service worker + icons. The game is fully client-side, so
-      installable + offline is nearly free and makes the web build feel like a real game.
-- [ ] SEO/social: OG image, meta tags, proper title/description per page.
-- [ ] Error tracking (Sentry) — you currently have zero visibility into player crashes.
-- [ ] Analytics events beyond page views: run started/finished, mode, score
-      (Vercel Analytics custom events or Plausible).
-- [ ] Privacy page (required once you have analytics) + Credits page (IBM Plex Mono OFL
-      attribution already lives in the repo).
+- [ ] **PWA** via `vite-plugin-pwa`: manifest + service worker + icons. The game is
+      fully client-side, so installable + offline is nearly free.
+- [ ] SEO/social: OG image, meta tags; revisit landing-page prerender here if organic
+      search matters.
+- [ ] Error tracking (Sentry) — currently zero visibility into player crashes.
+- [ ] Analytics events beyond page views: run started/finished, mode, score.
+- [ ] Privacy page (required once you have analytics) + Credits page (IBM Plex Mono
+      OFL attribution already lives in the repo).
 - [ ] Balance/playtest pass — get 5–10 people through full runs on all three modes.
 - [ ] Tag **v1.0.0**, announce.
 
 ## Phase 3 — Desktop release (Tauri)
 
-- [ ] Fix `tauri.conf.json`: real `identifier` (e.g. `live.cryptofrenzy.app`), product
-      name, window defaults (windowed, sensible min size), real icons from a source
-      logo (`tauri icon` generates the whole set).
+- [ ] Finish `tauri.conf.json`: window defaults (windowed, sensible min size), real
+      icons from a source logo (`tauri icon` generates the whole set).
 - [ ] Release CI: `tauri-action` GitHub workflow building macOS (universal), Windows,
       Linux on tag push → GitHub Releases.
-- [ ] Auto-updates via `tauri-plugin-updater` (worth doing before first release so
+- [ ] Auto-updates via `tauri-plugin-updater` (worth doing before first release so the
       update channel exists from day one).
 - [ ] **Signing decision** (see below): macOS Developer ID + notarization ($99/yr);
       Windows cert or ship unsigned with SmartScreen caveat.
 - [ ] Distribute: GitHub Releases + **itch.io** first (no signing gate, built-in
-      audience for small games, optional pay-what-you-want). Steam later if traction
-      ($100 fee, store page, review process).
+      audience for small games, optional pay-what-you-want). Steam later if traction.
 
 ## Phase 4 — Retention & depth (could-haves, post-1.0)
 
 Roughly in order of value-for-effort:
 
-1. **Daily challenge** — same seed for everyone each day (needs the Phase 1 RNG work;
-   no backend needed for the seed itself, just date-derived).
+1. **Daily challenge** — same seed for everyone each day (the Phase 1b RNG work makes
+   the seed date-derived; no backend needed).
 2. **Global leaderboard** — needs a tiny backend (decision below). Client-submitted
-   scores are spoofable; acceptable for casual play, or verify by replaying the
-   seeded action log server-side.
+   scores are spoofable; acceptable for casual play, or verify by replaying the seeded
+   action log server-side (also unlocked by the engine refactor).
 3. **Run history & stats** — local, cheap, makes single-player sticky.
 4. **Achievements** — local first ("paid off debt by day 5", "held a moonshot").
 5. **Content depth** — more coins (unlock by level?), events that act on the *player*
@@ -132,7 +143,15 @@ Roughly in order of value-for-effort:
 
 ---
 
-## Decisions to make
+## Architecture decisions log
+
+| Date | Decision | Why |
+|---|---|---|
+| 2026-07-01 | Persist runs as a versioned JSON save file | Format ports unchanged to Tauri (disk) and any future backend |
+| 2026-07-02 | **Drop Next.js for Vite + React SPA** | Server-first framework on a client-only game: hydration tax, CVE/upgrade treadmill, CI friction; Vite is Tauri's native pairing |
+| 2026-07-02 | **Reducer-as-game-engine, single-intent actions, seedable RNG** | Multi-dispatch helpers forced wrapper-reducer stats tracking (PR #31 review); engine design unlocks unit tests, daily seeds, replay verification |
+
+## Decisions still open
 
 | Decision | Options | Lean |
 |---|---|---|
@@ -145,9 +164,7 @@ Roughly in order of value-for-effort:
 
 ## Suggested sequencing
 
-Phases 0–1 are one continuous stretch of work (0 is an afternoon; 1 is the meat —
-call it 2–4 weekends). Phase 2 is a weekend. Phase 3 is a weekend plus signing
-paperwork latency. Phase 4 is open-ended, one feature at a time.
-
-Each checklist item above is roughly one PR. Phase 1a (persistence + game-over screen)
-is the single highest-impact chunk — it's the difference between a demo and a game.
+Phase 1b is next and comes as two PRs (Vite migration, then engine refactor) — swap
+the foundation before building on it. Phases 1c–1d are the feature meat (2–3
+weekends). Phase 2 is a weekend. Phase 3 is a weekend plus signing paperwork latency.
+Phase 4 is open-ended, one feature at a time.


### PR DESCRIPTION
## What

Updates ROADMAP.md to reflect the decisions from the [PR #31](https://github.com/whcarter3/crypto-frenzy/pull/31) review discussion:

- **New Phase 1b — Replatform**, next up, as two PRs:
  1. **Vite migration** — Next.js is a server-first framework on a client-only game; prerendering is the root cause of the hydration workarounds (`hydrated` flag, restore-in-effect, modal-flash gating) flagged in review, plus the CVE-upgrade treadmill and CI friction. Vite kills the hydration dance entirely (save reads synchronously in the reducer initializer) and is Tauri's native pairing.
  2. **Engine refactor** — reducer-as-game-engine with single-intent actions and a seedable RNG; removes the `trackPeakNetWorth` wrapper-reducer pattern and unlocks unit tests, daily seeds, and replay verification.
- Refreshed "where the game stands" to post-#31 reality (persistence, game-over screen, difficulty modes now shipped).
- Added an architecture decisions log alongside the still-open decisions table.
- Old phases 1b/1c renumbered to 1c/1d; the "engineering hardening" section folded into the engine refactor; Phase 2 PWA item now specifies `vite-plugin-pwa`.

Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)