### PR TITLE
feat: sound effects, settings panel, in-game how-to-play (Phase 1e)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,20 +6,23 @@ import {
 } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
 import { NotificationProvider } from './lib/NotificationContext';
+import { SettingsProvider } from './lib/SettingsContext';
 import Home from './pages/Home';
 import Game from './pages/Game';
 
 const App = () => (
-  <NotificationProvider>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/game" element={<Game />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </BrowserRouter>
-    {__VERCEL__ && <Analytics />}
-  </NotificationProvider>
+  <SettingsProvider>
+    <NotificationProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/game" element={<Game />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
+      {__VERCEL__ && <Analytics />}
+    </NotificationProvider>
+  </SettingsProvider>
 );
 
 export default App;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,33 +4,34 @@ Goal: take the current prototype (playable core loop, live at cryptofrenzy.live)
 releasable **v1.0 webapp**, then a **downloadable desktop build** via the existing Tauri
 scaffold, then optional retention features (leaderboards, daily runs).
 
-## Where the game stands (post Phase 1d)
+## Where the game stands (post Phase 1e)
 
 **Working:** core trade loop with quantity controls (amount input + Max, empty =
 max/all), 5 coins with low/mid/high/moon price bands, compounding debt, wallet
 capacity upgrades, event flavor text, difficulty modes (Easy/Normal/Hard), run
 persistence with resume-or-new from the landing page, a real game-over screen with
 run stats, per-mode high scores, seeded runs via `?seed=` (deterministic E2E, daily-
-challenge groundwork). **Vite + React SPA** (no framework tax), and the reducer is a
+challenge groundwork). Retro **sound effects** (Web Audio, no assets) with a
+**settings panel** (sound + CRT-effects toggles, reset high scores) and an in-game
+**How to play**. **Vite + React SPA** (no framework tax), and the reducer is a
 **pure, deterministic game engine** — seeded RNG in state, one intent per action,
 replayable from a seed + action log. `/game` is responsive (stacks below `lg`) and
-passes an automated **cypress-axe** WCAG scan (landing page, difficulty modal,
-in-game, game-over) with zero violations, plus a 375px viewport-overflow
-regression test. 44 Vitest unit tests + 18 Cypress E2E tests (12 functional +
-4 accessibility + 2 responsive), all in CI. Deployed on Vercel; Tauri 2
-scaffold builds.
+passes an automated **cypress-axe** WCAG scan (6 screens/states) with zero
+violations, plus a 375px viewport-overflow regression test. 49 Vitest unit tests +
+23 Cypress E2E tests, all in CI. Deployed on Vercel; Tauri 2 scaffold builds.
 
 **Known debt / still missing:**
 
-- **No settings, no sound, no in-game help** — stubbed "SOON" on the landing page
-  (Phase 1e, next up).
+- **UX is rough end-to-end** — responsive ≠ pleasant; comprehensive sweep is
+  Phase 1f, next up.
 - **Landing page is no longer prerendered** (accepted Vite tradeoff) — revisit with a
   prerender plugin in Phase 2 if organic search matters.
 - **Tauri scaffold half-configured** — identifier and product name are fixed, but
   default icons, `fullscreen: true`, and no release pipeline remain (Phase 3).
-- **Real-device spot check still worth doing** — mobile layout is now guarded by an
-  automated 375px Cypress test (see Phase 1d notes), but nobody has played a run on
-  an actual phone yet; worth a pass on the Vercel preview before v1.0.
+- **Real-device spot check still worth doing** — mobile layout is guarded by an
+  automated 375px Cypress test, but nobody has played a run on an actual phone yet;
+  worth a pass on the Vercel preview before v1.0. Sound deserves a real listen too —
+  the synthesized bleeps are tested for "plays without errors", not for taste.
 
 ---
 
@@ -152,13 +153,44 @@ touch the same layout-heavy components (`AssetTable`, `GameSidebar`, `Game`).
       main flex chain and removing `mx-auto`; the test now guards 375px through
       the full trade flow plus the desktop side-by-side layout.
 
-## Phase 1e — Presentation & feel
+## Phase 1e — Presentation & feel ✅ (done)
 
-- [ ] Sound effects (buy, sell, day tick, moonshot, game over) + music toggle; mute
-      persisted in settings.
-- [ ] Settings panel: sound, **CRT effects toggle** (manual override on top of the
-      1d `prefers-reduced-motion` support), reset high scores.
-- [ ] In-game "How to play" (the landing page copy is 80% of it already).
+- [x] Sound effects (buy, sell, pay, day tick, moonshot fanfare, game-over jingle,
+      last-day warning) — synthesized retro bleeps via Web Audio (`lib/sound.ts`),
+      zero assets, on-brand for a CRT terminal. Gated by the sound setting; safe
+      no-ops under SSR/tests/blocked-autoplay. Background *music* needs an actual
+      track and is deferred to the 1f UX sweep (a bad loop is worse than none).
+- [x] Settings panel (`components/Settings.tsx`): sound + CRT-effects toggles,
+      persisted in `cryptoFrenzySettings` localStorage (separate from game state —
+      device preference, not run state). CRT toggle is one `data-crt` attribute on
+      `<html>` + CSS overrides killing scanlines/flicker/glow; layered on the 1d
+      `prefers-reduced-motion` support. Reset-high-scores button included (takes
+      effect next run — the in-run display keeps the loaded value; UX-sweep nit).
+- [x] In-game "How to play" (`components/HowToPlay.tsx`): contract, daily loop,
+      market bands, seeds — including the load-bearing tip that unsold holdings
+      don't count toward the score. Both modals reachable from the sidebar and
+      covered by axe scans + E2E (toggles persist across reload).
+
+## Phase 1f — Comprehensive UX sweep (NEXT UP)
+
+The layout is *responsive* after 1d, but the moment-to-moment experience is rough
+(owner verdict 2026-07-03: "the UI is definitely responsive, but the UX is awful").
+One dedicated pass over how the game *feels* to play, mobile-first, before release
+polish in Phase 2. Candidate items — inventory properly at the start of the phase
+by playing full runs on phone + desktop:
+
+- [ ] Mobile information hierarchy: prices/actions likely belong above the sidebar
+      stats (currently a full screen of NET WORTH/HOLDINGS before the market is
+      visible); the Cash/Debt/Days chips live below the fold entirely.
+- [ ] Trade flow friction: buy/sell need less precision on a phone (bigger tap
+      targets, maybe a per-asset trade sheet instead of inline inputs).
+- [ ] Day-advance pacing and feedback: price changes are instant and silent — no
+      sense of what moved since yesterday (deltas, flash-on-change).
+- [ ] Log noise vs. signal: separators and flavor events drown the lines that
+      matter; consider grouping by day or highlighting events.
+- [ ] Oversized numbers (NET WORTH panel) vs. tiny controls; general type scale.
+- [ ] Landing page menu stubs (PROFILES/CREDITS "SOON") — ship or cut.
+- [ ] Background music (deferred from 1e — needs a real track or a decent loop).
 
 ## Phase 2 — Web release (v1.0 on cryptofrenzy.live)
 
@@ -215,6 +247,7 @@ Roughly in order of value-for-effort:
 | 2026-07-02 | **Drop Next.js for Vite + React SPA** | Server-first framework on a client-only game: hydration tax, CVE/upgrade treadmill, CI friction; Vite is Tauri's native pairing |
 | 2026-07-02 | **Reducer-as-game-engine, single-intent actions, seedable RNG** | Multi-dispatch helpers forced wrapper-reducer stats tracking (PR #31 review); engine design unlocks unit tests, daily seeds, replay verification |
 | 2026-07-03 | **Fold the mobile/tablet responsive pass into Phase 1d (accessibility)** | Both touch the same layout components; smaller viewports and assistive tech share a lot of the same fixes (focus order, semantic structure) |
+| 2026-07-03 | **Insert Phase 1f: comprehensive UX sweep before the Phase 2 release push** | Post-1d verdict: layout is responsive but the experience is rough — a dedicated feel/flow pass beats sprinkling UX fixes across release tasks |
 
 ## Decisions still open
 
@@ -229,6 +262,6 @@ Roughly in order of value-for-effort:
 
 ## Suggested sequencing
 
-Phases 0–1d are shipped. Next is 1e (presentation & feel — sound, settings,
-in-game help). Phase 2 is a weekend. Phase 3 is a weekend plus signing paperwork
+Phases 0–1e are shipped. Next is 1f (comprehensive UX sweep — inventory by
+playing real runs on phone + desktop, then fix). Phase 2 is a weekend. Phase 3 is a weekend plus signing paperwork
 latency. Phase 4 is open-ended, one feature at a time.

--- a/components/Actions.tsx
+++ b/components/Actions.tsx
@@ -1,5 +1,6 @@
 import { Dispatch } from 'react';
 import { Action, State } from '../lib/types';
+import { playSound } from '../lib/sound';
 import Chip from './Chip';
 
 const Actions = ({
@@ -30,7 +31,10 @@ const Actions = ({
             bool: canPayDebt,
             label: 'Pay',
             id: 'payDebt',
-            action: () => dispatch({ type: 'PAY_DEBT' }),
+            action: () => {
+              dispatch({ type: 'PAY_DEBT' });
+              playSound('pay');
+            },
             title: canPayDebt
               ? 'You need more cash than debt to pay it off in full'
               : 'Pay off your full debt',
@@ -44,7 +48,10 @@ const Actions = ({
             bool: isGameOver,
             label: 'Adv Day',
             id: 'advDay',
-            action: () => dispatch({ type: 'ADVANCE_DAY' }),
+            action: () => {
+              dispatch({ type: 'ADVANCE_DAY' });
+              playSound('advance');
+            },
             title: isGameOver
               ? 'The run is over'
               : 'End the day: prices re-roll and debt compounds',

--- a/components/AssetTable.tsx
+++ b/components/AssetTable.tsx
@@ -2,6 +2,7 @@ import { Dispatch, useState } from 'react';
 import { State, Action } from '../lib/types';
 import { calculateMaxShares, numberWithCommas } from '../helpers/utils';
 import { cn } from '../lib/cn';
+import { playSound } from '../lib/sound';
 
 const AssetTable = ({
   state,
@@ -25,6 +26,7 @@ const AssetTable = ({
         amount: Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
       },
     });
+    playSound('buy');
     setAmount(assetKey, '');
   };
 

--- a/components/GameSidebar.tsx
+++ b/components/GameSidebar.tsx
@@ -10,14 +10,19 @@ import { cn } from '../lib/cn';
 import { clearSave } from '../lib/state/persistence';
 import { loadHighScore } from '../lib/state/highScores';
 import { useNotification } from '../lib/NotificationContext';
+import { playSound } from '../lib/sound';
 import Chip from './Chip';
 
 const GameSidebar = ({
   state,
   dispatch,
+  onOpenSettings,
+  onOpenHelp,
 }: {
   state: State;
   dispatch: Dispatch<Action>;
+  onOpenSettings: () => void;
+  onOpenHelp: () => void;
 }) => {
   const { showNotification } = useNotification();
 
@@ -50,6 +55,7 @@ const GameSidebar = ({
         amount: Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
       },
     });
+    playSound('sell');
     setAmount(assetKey, '');
   };
 
@@ -246,6 +252,25 @@ const GameSidebar = ({
       >
         new game
       </button>
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onOpenHelp}
+          className="btn flex-1 py-2 px-3 text-xs font-semibold"
+          id="openHowToPlay"
+        >
+          How to play
+        </button>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="btn flex-1 py-2 px-3 text-xs font-semibold"
+          id="openSettings"
+        >
+          Settings
+        </button>
+      </div>
 
       {hasHighScore ? (
         <>

--- a/components/HowToPlay.tsx
+++ b/components/HowToPlay.tsx
@@ -1,0 +1,101 @@
+const HowToPlay = ({ onClose }: { onClose: () => void }) => {
+  return (
+    <div
+      className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-10 flex items-center justify-center p-4 md:p-8"
+      data-cy="howToPlayScreen"
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        className="bg-black w-full max-w-2xl max-h-[85vh] rounded-sm border border-crt-yellow box-shadow-crt p-6 md:p-8 space-y-5 overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="howToPlayTitle"
+        tabIndex={0}
+      >
+        <h1
+          id="howToPlayTitle"
+          className="text-2xl font-bold text-slate-300 text-glow-crt"
+        >
+          How to play
+        </h1>
+
+        <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
+          <h2 className="text-crt-green text-base font-semibold">
+            Your contract
+          </h2>
+          <p>
+            You start in debt, with a little cash and a wallet that only
+            holds so many coins. Survive the run and finish with as much
+            money as you can.
+          </p>
+          <p className="text-crt-yellow">
+            Your score is cash minus debt — coins still in your wallet
+            when the run ends count for nothing. Sell before the final
+            day, and pay off the loan.
+          </p>
+        </section>
+
+        <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
+          <h2 className="text-crt-cyan text-base font-semibold">
+            Each day
+          </h2>
+          <ul className="space-y-1 list-disc list-inside">
+            <li>
+              <span className="text-crt-green">Adv Day</span> re-rolls
+              every price and compounds your debt.
+            </li>
+            <li>
+              Buy low, sell high. Leave the amount empty to buy the max
+              you can afford, or sell a whole position.
+            </li>
+            <li>
+              <span className="text-crt-green">Pay</span> clears your
+              debt in full once you have more cash than debt — interest
+              is brutal, don&apos;t sit on it.
+            </li>
+            <li>
+              Expand your wallet when capacity pinches — each upgrade
+              doubles it, and doubles the next upgrade&apos;s price.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
+          <h2 className="text-crt-cyan text-base font-semibold">
+            The market
+          </h2>
+          <p>
+            Prices swing between crash, normal, and hot ranges — and once
+            in a while a coin <span className="text-crt-green">moons</span>.
+            Watch the activity feed: news events tell you when something
+            crashed or took off.
+          </p>
+        </section>
+
+        <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
+          <h2 className="text-crt-cyan text-base font-semibold">
+            Seeds
+          </h2>
+          <p>
+            Every run has a market seed. The same seed always produces
+            the same prices and events — copy the seed link from the
+            sidebar or game-over screen to race a friend on the exact
+            same market.
+          </p>
+        </section>
+
+        <button
+          className="btn btn-primary w-full py-3"
+          onClick={onClose}
+          id="howToPlayClose"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default HowToPlay;

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,0 +1,109 @@
+import { useSettings } from '../lib/SettingsContext';
+import { clearHighScores } from '../lib/state/highScores';
+import { useNotification } from '../lib/NotificationContext';
+import { cn } from '../lib/cn';
+
+const Toggle = ({
+  id,
+  label,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) => (
+  <div className="flex items-center justify-between gap-4">
+    <span className="text-slate-300">{label}</span>
+    <button
+      type="button"
+      id={id}
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        'btn w-28',
+        checked && 'btn-primary',
+        !checked && 'bg-black text-slate-400 border-slate-600',
+      )}
+    >
+      {checked ? 'On' : 'Off'}
+    </button>
+  </div>
+);
+
+const Settings = ({ onClose }: { onClose: () => void }) => {
+  const { settings, update } = useSettings();
+  const { showNotification } = useNotification();
+
+  const handleResetScores = () => {
+    clearHighScores();
+    showNotification(
+      'High scores cleared — takes effect from your next run',
+      'info',
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-10 flex items-center justify-center p-4 md:p-8"
+      data-cy="settingsScreen"
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        className="bg-black w-full max-w-md rounded-sm border border-crt-yellow box-shadow-crt p-6 md:p-8 space-y-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settingsTitle"
+        tabIndex={0}
+      >
+        <h1
+          id="settingsTitle"
+          className="text-2xl font-bold text-slate-300 text-glow-crt"
+        >
+          Settings
+        </h1>
+
+        <div className="space-y-4">
+          <Toggle
+            id="soundToggle"
+            label="Sound effects"
+            checked={settings.sound}
+            onChange={(sound) => update({ sound })}
+          />
+          <Toggle
+            id="crtToggle"
+            label="CRT effects (scanlines, glow)"
+            checked={settings.crt}
+            onChange={(crt) => update({ crt })}
+          />
+        </div>
+
+        <div className="border-t border-white/10 pt-4">
+          <button
+            type="button"
+            id="resetScores"
+            onClick={handleResetScores}
+            className="btn btn-danger w-full py-2 text-sm"
+          >
+            Reset high scores
+          </button>
+        </div>
+
+        <button
+          className="btn btn-primary w-full py-3"
+          onClick={onClose}
+          id="settingsClose"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -50,4 +50,22 @@ describe("Accessibility (axe)", () => {
     cy.injectAxe()
     cy.checkA11y(undefined, undefined, logViolations)
   })
+
+  it("settings modal has no violations", () => {
+    cy.visit("http://localhost:3000/game?seed=42")
+    cy.get("#startGame").click()
+    cy.get("#openSettings").click()
+    cy.get("[data-cy='settingsScreen']").should("be.visible")
+    cy.injectAxe()
+    cy.checkA11y(undefined, undefined, logViolations)
+  })
+
+  it("how-to-play modal has no violations", () => {
+    cy.visit("http://localhost:3000/game?seed=42")
+    cy.get("#startGame").click()
+    cy.get("#openHowToPlay").click()
+    cy.get("[data-cy='howToPlayScreen']").should("be.visible")
+    cy.injectAxe()
+    cy.checkA11y(undefined, undefined, logViolations)
+  })
 })

--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -1,0 +1,57 @@
+describe("Settings & How to play", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/game?seed=42")
+    cy.clearAllLocalStorage()
+    cy.reload()
+    cy.get("#startGame").click()
+  })
+
+  it("opens settings, toggles persist across a reload", () => {
+    cy.get("#openSettings").click()
+    cy.get("[data-cy='settingsScreen']").should("be.visible")
+
+    cy.get("#soundToggle")
+      .should("have.attr", "aria-checked", "true")
+      .click()
+      .should("have.attr", "aria-checked", "false")
+
+    cy.get("#crtToggle").click()
+    // the CRT toggle stamps a data attribute on <html>
+    cy.document()
+      .its("documentElement.dataset.crt")
+      .should("eq", "off")
+
+    cy.get("#settingsClose").click()
+    cy.get("[data-cy='settingsScreen']").should("not.exist")
+
+    cy.reload()
+    cy.get("#openSettings").click()
+    cy.get("#soundToggle").should("have.attr", "aria-checked", "false")
+    cy.get("#crtToggle").should("have.attr", "aria-checked", "false")
+    cy.document()
+      .its("documentElement.dataset.crt")
+      .should("eq", "off")
+  })
+
+  it("reset high scores clears stored records", () => {
+    cy.window().then((win) => {
+      win.localStorage.setItem("highScore", "12345")
+      win.localStorage.setItem("highScoreEasy", "999")
+    })
+    cy.get("#openSettings").click()
+    cy.get("#resetScores").click()
+    cy.contains("High scores cleared").should("be.visible")
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem("highScore")).to.be.null
+      expect(win.localStorage.getItem("highScoreEasy")).to.be.null
+    })
+  })
+
+  it("opens and closes how to play", () => {
+    cy.get("#openHowToPlay").click()
+    cy.get("[data-cy='howToPlayScreen']").should("be.visible")
+    cy.contains("cash minus debt").should("be.visible")
+    cy.get("#howToPlayClose").click()
+    cy.get("[data-cy='howToPlayScreen']").should("not.exist")
+  })
+})

--- a/lib/SettingsContext.tsx
+++ b/lib/SettingsContext.tsx
@@ -1,0 +1,57 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  Settings,
+  loadSettings,
+  saveSettings,
+} from './state/settings';
+import { setSoundEnabled } from './sound';
+
+interface SettingsContextType {
+  settings: Settings;
+  update: (patch: Partial<Settings>) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(
+  undefined,
+);
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error(
+      'useSettings must be used within a SettingsProvider',
+    );
+  }
+  return context;
+};
+
+export const SettingsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [settings, setSettings] = useState<Settings>(loadSettings);
+
+  // Settings take effect here so every consumer stays dumb: the sound
+  // module reads a flag, the CRT override is pure CSS keyed off a data
+  // attribute on <html>.
+  useEffect(() => {
+    saveSettings(settings);
+    setSoundEnabled(settings.sound);
+    document.documentElement.dataset.crt = settings.crt ? 'on' : 'off';
+  }, [settings]);
+
+  const update = (patch: Partial<Settings>) =>
+    setSettings((prev) => ({ ...prev, ...patch }));
+
+  return (
+    <SettingsContext.Provider value={{ settings, update }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};

--- a/lib/sound.ts
+++ b/lib/sound.ts
@@ -1,0 +1,112 @@
+/**
+ * Retro sound effects, synthesized with the Web Audio API — no audio
+ * assets, which suits both the CRT-terminal aesthetic and the bundle.
+ *
+ * The module is a side-effect layer, deliberately outside the pure
+ * engine: components fire sounds from event handlers/effects, and the
+ * SettingsProvider flips `enabled`. Everything no-ops safely when
+ * audio is unavailable (SSR, tests, autoplay-blocked contexts).
+ */
+
+type SoundName =
+  | 'buy'
+  | 'sell'
+  | 'pay'
+  | 'advance'
+  | 'moonshot'
+  | 'gameOver'
+  | 'warning';
+
+let enabled = true;
+let ctx: AudioContext | null = null;
+
+export const setSoundEnabled = (on: boolean): void => {
+  enabled = on;
+};
+
+const getContext = (): AudioContext | null => {
+  if (typeof window === 'undefined') return null;
+  const AC =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!AC) return null;
+  // Lazy singleton: browsers only allow audio after a user gesture, and
+  // every sound here is triggered by a click, so creation/resume is safe.
+  if (!ctx) ctx = new AC();
+  if (ctx.state === 'suspended') void ctx.resume();
+  return ctx;
+};
+
+/** One decaying square-wave note, `start` seconds from now. */
+const note = (
+  audio: AudioContext,
+  freq: number,
+  start: number,
+  duration: number,
+  type: OscillatorType = 'square',
+  volume = 0.03,
+) => {
+  const osc = audio.createOscillator();
+  const gain = audio.createGain();
+  const t = audio.currentTime + start;
+  osc.type = type;
+  osc.frequency.value = freq;
+  gain.gain.setValueAtTime(volume, t);
+  gain.gain.exponentialRampToValueAtTime(0.0001, t + duration);
+  osc.connect(gain);
+  gain.connect(audio.destination);
+  osc.start(t);
+  osc.stop(t + duration);
+};
+
+// Note frequencies (Hz)
+const C4 = 261.63;
+const E4 = 329.63;
+const G4 = 392.0;
+const C5 = 523.25;
+const E5 = 659.25;
+const G5 = 783.99;
+const C6 = 1046.5;
+
+export const playSound = (name: SoundName): void => {
+  if (!enabled) return;
+  const audio = getContext();
+  if (!audio) return;
+  try {
+    switch (name) {
+      case 'buy':
+        note(audio, C5, 0, 0.08);
+        note(audio, E5, 0.07, 0.1);
+        break;
+      case 'sell':
+        note(audio, E5, 0, 0.08);
+        note(audio, C5, 0.07, 0.1);
+        break;
+      case 'pay':
+        note(audio, G5, 0, 0.09);
+        note(audio, C6, 0.08, 0.14);
+        break;
+      case 'advance':
+        note(audio, 880, 0, 0.05, 'triangle', 0.025);
+        break;
+      case 'moonshot':
+        note(audio, C5, 0, 0.09);
+        note(audio, E5, 0.08, 0.09);
+        note(audio, G5, 0.16, 0.09);
+        note(audio, C6, 0.24, 0.22);
+        break;
+      case 'gameOver':
+        note(audio, G4, 0, 0.16, 'sawtooth');
+        note(audio, E4, 0.15, 0.16, 'sawtooth');
+        note(audio, C4, 0.3, 0.35, 'sawtooth');
+        break;
+      case 'warning':
+        note(audio, 220, 0, 0.15, 'square', 0.035);
+        note(audio, 185, 0.16, 0.2, 'square', 0.035);
+        break;
+    }
+  } catch {
+    // audio is best-effort, never break the game over it
+  }
+};

--- a/lib/state/highScores.test.ts
+++ b/lib/state/highScores.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { loadHighScore, saveHighScore } from './highScores';
+import {
+  clearHighScores,
+  loadHighScore,
+  saveHighScore,
+} from './highScores';
 
 const store = new Map<string, string>();
 
@@ -34,5 +38,14 @@ describe('high scores', () => {
   it('never writes in Test mode', () => {
     saveHighScore('Test', 999);
     expect(store.size).toBe(0);
+  });
+
+  it('clearHighScores wipes every mode', () => {
+    saveHighScore('Normal', 100);
+    saveHighScore('Easy', 200);
+    saveHighScore('Hard', 300);
+    clearHighScores();
+    expect(store.size).toBe(0);
+    expect(loadHighScore('Normal')).toBeNull();
   });
 });

--- a/lib/state/highScores.ts
+++ b/lib/state/highScores.ts
@@ -34,3 +34,15 @@ export const saveHighScore = (
     // ignore — losing a high score write beats crashing the game
   }
 };
+
+/** Wipes the records for every mode (Settings → reset high scores). */
+export const clearHighScores = (): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    (['Easy', 'Normal', 'Hard'] as const).forEach((mode) =>
+      localStorage.removeItem(keyFor(mode)),
+    );
+  } catch {
+    // ignore
+  }
+};

--- a/lib/state/settings.test.ts
+++ b/lib/state/settings.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  defaultSettings,
+  loadSettings,
+  saveSettings,
+} from './settings';
+
+const store = new Map<string, string>();
+
+beforeEach(() => {
+  store.clear();
+  (globalThis as unknown as { window: unknown }).window = globalThis;
+  (globalThis as unknown as { localStorage: unknown }).localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) =>
+      void store.set(key, String(value)),
+    removeItem: (key: string) => void store.delete(key),
+  };
+});
+
+describe('settings', () => {
+  it('returns defaults when nothing is stored', () => {
+    expect(loadSettings()).toEqual(defaultSettings);
+  });
+
+  it('round-trips', () => {
+    saveSettings({ sound: false, crt: false });
+    expect(loadSettings()).toEqual({ sound: false, crt: false });
+  });
+
+  it('merges stored values over defaults (forward compat)', () => {
+    store.set('cryptoFrenzySettings', JSON.stringify({ sound: false }));
+    expect(loadSettings()).toEqual({ ...defaultSettings, sound: false });
+  });
+
+  it('falls back to defaults on corrupt storage', () => {
+    store.set('cryptoFrenzySettings', 'not json {');
+    expect(loadSettings()).toEqual(defaultSettings);
+  });
+});

--- a/lib/state/settings.ts
+++ b/lib/state/settings.ts
@@ -1,0 +1,41 @@
+/**
+ * App preferences — deliberately separate from game State: they're
+ * device-level, not part of a run, so they don't belong in the seeded
+ * save file or the engine's replayable state.
+ */
+
+export type Settings = {
+  /** Sound effects on/off */
+  sound: boolean;
+  /** CRT visual effects (scanlines, glow) on/off */
+  crt: boolean;
+};
+
+const SETTINGS_KEY = 'cryptoFrenzySettings';
+
+export const defaultSettings: Settings = {
+  sound: true,
+  crt: true,
+};
+
+export const loadSettings = (): Settings => {
+  if (typeof window === 'undefined') return defaultSettings;
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return defaultSettings;
+    const parsed = JSON.parse(raw);
+    // Merge over defaults so newly added settings pick up their default
+    return { ...defaultSettings, ...parsed };
+  } catch {
+    return defaultSettings;
+  }
+};
+
+export const saveSettings = (settings: Settings): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // storage unavailable — settings just won't persist
+  }
+};

--- a/pages/Game.tsx
+++ b/pages/Game.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 import { reducer } from '../lib/reducer';
 import { initialState } from '../lib/state/initialState';
 import {
@@ -8,6 +8,7 @@ import {
 } from '../lib/state/persistence';
 import { saveHighScore } from '../lib/state/highScores';
 import { useNotification } from '../lib/NotificationContext';
+import { playSound } from '../lib/sound';
 import { AlertMessages } from '../helpers/alerts';
 import { usePageTitle } from '../helpers/usePageTitle';
 import AssetTable from '../components/AssetTable';
@@ -16,6 +17,8 @@ import GameSidebar from '../components/GameSidebar';
 import Log from '../components/Log';
 import GameMode from '../components/GameMode';
 import GameOver from '../components/GameOver';
+import Settings from '../components/Settings';
+import HowToPlay from '../components/HowToPlay';
 
 export default function Game() {
   usePageTitle('Crypto Frenzy – Game');
@@ -46,6 +49,10 @@ export default function Game() {
     }
   }, [state]);
 
+  // UI-only chrome, not game state: never saved, never seeded.
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+
   // The engine is pure — localStorage writes happen out here.
   useEffect(() => {
     if (state.gameOver?.newHighScore) {
@@ -53,11 +60,32 @@ export default function Game() {
     }
   }, [state.gameOver, state.mode]);
 
+  // Sound is a side effect too: the run-settled jingle keys off
+  // gameOver flipping, the moonshot fanfare off the day's fresh log
+  // entries (everything above the newest day separator).
+  useEffect(() => {
+    if (state.gameOver) playSound('gameOver');
+  }, [state.gameOver]);
+
+  useEffect(() => {
+    if (state.currentDay <= 1) return;
+    const todaysEntries: string[] = [];
+    for (const entry of state.log) {
+      if (entry.startsWith('=========')) break;
+      todaysEntries.push(entry);
+    }
+    if (todaysEntries.some((entry) => entry.includes('MOONSHOT'))) {
+      playSound('moonshot');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.currentDay]);
+
   // Warn when one in-game day remains.
   const { showNotification } = useNotification();
   useEffect(() => {
     if (!state.gameOver && state.currentDay === state.days - 1) {
       showNotification(AlertMessages.LAST_DAY, 'warning');
+      playSound('warning');
     }
   }, [state.currentDay, state.days, state.gameOver, showNotification]);
 
@@ -76,7 +104,12 @@ export default function Game() {
             contained by a landmark region. */}
         <h1 className="sr-only">Crypto Frenzy – Game</h1>
         <div className="w-full lg:w-1/4 lg:shrink-0 min-w-0 border-b lg:border-b-0 lg:border-r border-white/10 bg-crt-panel/50 px-4 py-6">
-          <GameSidebar state={state} dispatch={dispatch} />
+          <GameSidebar
+            state={state}
+            dispatch={dispatch}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenHelp={() => setHelpOpen(true)}
+          />
         </div>
 
         {/* No mx-auto: auto margins disable flex-item stretch, which at
@@ -102,6 +135,10 @@ export default function Game() {
       {state.gameOver && (
         <GameOver state={state} dispatch={dispatch} />
       )}
+      {settingsOpen && (
+        <Settings onClose={() => setSettingsOpen(false)} />
+      )}
+      {helpOpen && <HowToPlay onClose={() => setHelpOpen(false)} />}
     </div>
   );
 }

--- a/styles/crt.css
+++ b/styles/crt.css
@@ -76,3 +76,26 @@
     0 0 1px rgba(0, 255, 0, 0.4),
     0 0 2px rgba(0, 255, 0, 0.3);
 }
+
+/* Manual CRT-effects kill switch (Settings panel). The SettingsProvider
+   stamps data-crt on <html>; this is the whole implementation — no
+   component needs to know the setting exists. Layered on top of the
+   prefers-reduced-motion support, which only stops the animations. */
+html[data-crt="off"] .crt-scanlines::after,
+html[data-crt="off"] .crt::before,
+html[data-crt="off"] .crt::after {
+  display: none;
+}
+
+html[data-crt="off"] * {
+  text-shadow: none !important;
+}
+
+html[data-crt="off"] .box-shadow-crt {
+  box-shadow: none;
+}
+
+html[data-crt="off"] .btn-primary,
+html[data-crt="off"] .btn-danger {
+  box-shadow: none;
+}


### PR DESCRIPTION
## What

Phase 1e presentation & feel, plus the new **Phase 1f (comprehensive UX sweep)** added to the roadmap per your call that the UI is responsive but the UX needs a dedicated pass.

### Sound
- Retro bleeps **synthesized with Web Audio** (`lib/sound.ts`) — buy, sell, pay-debt, day tick, moonshot fanfare, game-over jingle, last-day warning. Zero audio assets, on-brand for a CRT terminal, ~100 lines.
- Sounds are a side-effect layer outside the pure engine: event handlers fire trade/day sounds, effects watch `gameOver` and the day's fresh log entries for the fanfares. Safe no-ops under SSR/tests/blocked autoplay.
- **Deferred:** background music — needs an actual track; a bad loop is worse than none. Logged under Phase 1f.

### Settings (`components/Settings.tsx`)
- **Sound** and **CRT effects** toggles, persisted in `cryptoFrenzySettings` localStorage — deliberately separate from game State (device preference, not run state; stays out of the seeded save).
- The CRT toggle stamps `data-crt` on `<html>`; CSS overrides kill scanlines/flicker/glow. No component knows the setting exists. Layered on 1d's `prefers-reduced-motion` support.
- **Reset high scores** (all three modes) — takes effect from the next run; the in-run display keeps its loaded value (noted as a UX-sweep nit).

### How to play (`components/HowToPlay.tsx`)
- Contract, daily loop, market bands, seed sharing — including the genuinely load-bearing tip that **unsold holdings count for nothing** at settle.
- Both modals use the established dialog pattern (`role=dialog`, `aria-modal`, labelled, Escape closes) and open from new sidebar buttons.

## Tests

- **49 unit** (+5: settings roundtrip/merge-defaults/corrupt-storage, clearHighScores)
- **23 E2E** (+3: toggle persistence across reload, reset scores, how-to-play; +2 axe scans of the new modals — still zero WCAG violations across all 6 scanned states)
- Verified in-browser: settings modal, CRT toggle visibly flattening the glow/scanlines, how-to-play rendering; zero console errors.
- **Honest caveat:** the bleeps are tested for "plays without errors," not for taste — worth a listen on the preview before merging. Tuning is one constant per note in `lib/sound.ts`.

ROADMAP updated: 1e ticked, 1f (UX sweep) inserted with candidate items and decision-log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)