### PR TITLE
fix: remove invisible test-mode button from difficulty modal

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -237,6 +237,13 @@ polish in Phase 2.
       dividers between sidebar / activity log / market so players allocate
       screen space to what they care about (log readers vs. table watchers).
       Pairs naturally with E3; persist sizes in settings, not game state.
+- [x] E5: Removed the invisible 1×1 `#testMode` button from the difficulty modal.
+      It shipped to production, was keyboard-focusable, and announced "Enable test
+      mode" to screen readers; a leftover Cypress hook from PR #5 that the E2E
+      rewrite orphaned — nothing references it anymore. The `Test` entry in
+      `lib/state/modes.ts` stays: unit tests and the reducer's high-score gating
+      use it, and DEV-gating it would break the `Record<State['mode'], …>`
+      contract and crash restored old Test-mode saves.
 - [ ] Landing page menu stubs (PROFILES/CREDITS "SOON") — ship or cut.
 - [ ] Background music (deferred from 1e — needs a real track or a decent loop).
 

--- a/components/GameMode.tsx
+++ b/components/GameMode.tsx
@@ -213,15 +213,6 @@ const GameMode = ({
             Start Game!
           </button>
         </div>
-
-        <button
-          className="w-[1px] h-[1px] opacity-0"
-          onClick={() =>
-            dispatch({ type: 'CHANGE_MODE', payload: 'Test' })
-          }
-          id="testMode"
-          aria-label="Enable test mode"
-        ></button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
The difficulty modal rendered an invisible 1×1 `opacity-0` button (`#testMode`, aria-label "Enable test mode") that dispatched `CHANGE_MODE → 'Test'`. It shipped to production, was keyboard-focusable, and appeared in the accessibility tree — a Tab-stop that announced "Enable test mode" to screen-reader users and silently switched them into the $1M-cash test mode if activated.

It was a Cypress hook introduced with the original E2E setup (#5); the E2E rewrite (62ab962) dropped the spec that used it. `grep -ri testmode` across the repo finds nothing but the button's own `id` — no Cypress spec or dev workflow references it. Deleted.

**Kept `Test` in `lib/state/modes.ts`** rather than gating it behind `import.meta.env.DEV`: unit tests (`reducer.test.ts`, `highScores.test.ts`) and the reducer's high-score gating (`state.mode !== 'Test'`) depend on the entry, and a DEV-only key would break the `Record<State['mode'], ModeConfig>` type contract and crash any restored old Test-mode save in production. With the button gone there is no UI path to Test mode in prod; the config entry is a few inert bytes.

ROADMAP.md: logged as E5 in the 1f odds-and-ends inventory per project convention.

## Verification
- `tsc --noEmit` ✅  `npm run lint` ✅
- `npm run test:unit` — 52/52 ✅
- `npm run build` + `serve -s dist -l 3000` + `npx cypress run` — 23/23 across all 4 specs (incl. axe accessibility) ✅
- Inspected the served production build's accessibility tree: dialog now exposes only Easy / Normal / Hard / seed input / Start Game!; `document.getElementById('testMode')` → null

🤖 Generated with [Claude Code](https://claude.com/claude-code)