### PR TITLE
feat: executing a trade closes the modal immediately

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,9 +233,10 @@ polish in Phase 2.
       modal is now **tabbed Buy | Sell**: one info block up top (price, Δ,
       cash, space, position), one stepper playground in the middle, one
       full-width execute at the bottom. Market rows open the Buy tab,
-      holdings rows open Sell; both tabs' amounts survive switching. Done
-      replaced by a ✕ dismiss in the corner, clear button is a ✕ icon,
-      AVG. PRICE header shortened to AVG.
+      holdings rows open Sell; both tabs' amounts survive switching;
+      executing a trade closes the modal immediately — the updated table
+      row is the feedback. Done replaced by a ✕ dismiss in the corner,
+      clear button is a ✕ icon, AVG. PRICE header shortened to AVG.
 
 *D. Controls polish*
 - [x] D1: "max" placeholder next to a "MAX" button reads as a stutter — pick one.

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -13,9 +13,9 @@ export type TradeSide = 'buy' | 'sell';
  * buy+sell layout made you "look all over the place to parse what to
  * do", so the modal is now tabbed — one side at a time, reading top to
  * bottom as info → playground → execute. Market rows open the Buy tab,
- * holdings rows open Sell. Both tabs' amounts survive switching, and
- * the modal stays open after a trade so the updated position is the
- * feedback.
+ * holdings rows open Sell. Both tabs' amounts survive switching.
+ * Executing a trade closes the modal immediately (owner call,
+ * 2026-07-16) — the updated table row is the feedback.
  */
 const TradeModal = ({
   assetKey,
@@ -73,6 +73,7 @@ const TradeModal = ({
       payload: { assetKey, amount: buy.quantity },
     });
     playSound('buy');
+    onClose();
   };
 
   const handleSell = () => {
@@ -82,6 +83,7 @@ const TradeModal = ({
       payload: { assetKey, amount: sell.quantity },
     });
     playSound('sell');
+    onClose();
   };
 
   const tab = (tabSide: TradeSide, label: string) => (

--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -32,8 +32,9 @@ describe("Accessibility (axe)", () => {
     cy.get("#startGame").click()
     cy.get("#advDay").click()
     cy.get("[data-cy='solanaRow']").click()
+    // buying closes the modal, leaving the in-game screen with a holding
     cy.get("[data-cy='solanaBuyButton']").click()
-    cy.get("#tradeModalClose").click()
+    cy.get("[data-cy='tradeModal']").should("not.exist")
     cy.injectAxe()
     cy.checkA11y(undefined, undefined, logViolations)
   })
@@ -41,13 +42,15 @@ describe("Accessibility (axe)", () => {
   it("trade modal has no violations on either tab", () => {
     cy.visit("http://localhost:3000/game?seed=42")
     cy.get("#startGame").click()
-    // buy first so the position line and sell controls render
+    // buy first (closes the modal) so the position line and sell
+    // controls render, then reopen from the holdings row on Sell
     cy.get("[data-cy='solanaRow']").click()
     cy.get("[data-cy='solanaBuyButton']").click()
+    cy.get("[data-cy='solanaHoldingRow']").click()
     cy.get("[data-cy='tradeModal']").should("be.visible")
     cy.injectAxe()
     cy.checkA11y(undefined, undefined, logViolations)
-    cy.get("[data-cy='solanaSellTab']").click()
+    cy.get("[data-cy='solanaBuyTab']").click()
     cy.checkA11y(undefined, undefined, logViolations)
   })
 
@@ -71,8 +74,8 @@ describe("Accessibility (axe)", () => {
     cy.visit("http://localhost:3000/game?seed=42")
     cy.get("#startGame").click({ force: true })
     cy.get("[data-cy='solanaRow']").click({ force: true })
+    // buying closes the modal on its own
     cy.get("[data-cy='solanaBuyButton']").click({ force: true })
-    cy.get("#tradeModalClose").click({ force: true })
     cy.get("[data-cy='marketTable']").should("exist")
     cy.injectAxe()
     cy.checkA11y(undefined, undefined, logViolations)

--- a/cypress/e2e/features.cy.ts
+++ b/cypress/e2e/features.cy.ts
@@ -35,11 +35,17 @@ describe("Testing main features and function", () => {
     )
     cy.get("[data-cy='solanaMaxButton']").click()
     cy.get("[data-cy='solanaBuyButton']").click()
-    // modal stays open; the Sell tab carries the new position
+    // executing closes the modal — the updated row is the feedback
+    cy.get("[data-cy='tradeModal']").should("not.exist")
+    cy.get("[data-cy='solanaAssetWallet']")
+      .invoke("text")
+      .then(parseInt)
+      .should("be.gt", 0)
+    // reopen from the market row and sell the lot
+    cy.get("[data-cy='solanaRow']").click()
     cy.get("[data-cy='solanaSellTab']").click()
     cy.get("[data-cy='solanaSellMaxButton']").click()
     cy.get("[data-cy='solanaSellButton']").click()
-    cy.get("#tradeModalClose").click()
     cy.get("[data-cy='tradeModal']").should("not.exist")
     cy.get("[data-cy='solanaAssetWallet']")
       .invoke("text")
@@ -53,18 +59,17 @@ describe("Testing main features and function", () => {
     // stepper defaults to 1; typed values replace it
     cy.get("[data-cy='solanaAmountInput']").clear().type("2")
     cy.get("[data-cy='solanaBuyButton']").click()
-    // sell stepper defaults to 1
-    cy.get("[data-cy='solanaSellTab']").click()
+    cy.get("[data-cy='solanaAssetWallet']").should("have.text", "2")
+    // holdings row reopens straight onto Sell; stepper defaults to 1
+    cy.get("[data-cy='solanaHoldingRow']").click()
     cy.get("[data-cy='solanaSellButton']").click()
-    cy.get("#tradeModalClose").click()
     cy.get("[data-cy='solanaAssetWallet']").should("have.text", "1")
   })
 
   it("holdings rows open the modal on the Sell tab", () => {
     cy.get("#advDay").click()
     cy.get("[data-cy='solanaRow']").click()
-    cy.get("[data-cy='solanaBuyButton']").click() // buys default 1
-    cy.get("#tradeModalClose").click()
+    cy.get("[data-cy='solanaBuyButton']").click() // buys 1, closes
     cy.get("[data-cy='solanaHoldingRow']").click()
     cy.get("[data-cy='tradeModal']").should("be.visible")
     // the row you tapped says which side you're thinking about
@@ -75,6 +80,7 @@ describe("Testing main features and function", () => {
     )
     cy.get("[data-cy='solanaSellButton']").should("not.be.disabled")
     cy.get("#tradeModalClose").click()
+    cy.get("[data-cy='tradeModal']").should("not.exist")
   })
 
   it("clamps typed amounts and disables the action at zero", () => {
@@ -165,7 +171,6 @@ describe("Testing main features and function", () => {
     cy.get("#advDay").click()
     cy.get("[data-cy='solanaRow']").click()
     cy.get("[data-cy='solanaBuyButton']").click()
-    cy.get("#tradeModalClose").click()
     cy.get("[data-cy='days left']").should("have.text", "29")
     cy.reload()
     cy.get("[data-cy='days left']").should("have.text", "29")

--- a/cypress/e2e/responsive.cy.ts
+++ b/cypress/e2e/responsive.cy.ts
@@ -46,8 +46,8 @@ describe("Responsive layout", () => {
     noTableOverflow("day advanced")
     cy.get("[data-cy='solanaRow']").click({ force: true })
     noHorizontalOverflow("trade modal open")
+    // buying closes the modal on its own
     cy.get("[data-cy='solanaBuyButton']").click({ force: true })
-    cy.get("#tradeModalClose").click({ force: true })
     // holding a coin adds the holding marker + avg price to the row
     noTableOverflow("holding a coin")
     noHorizontalOverflow("modal closed")


### PR DESCRIPTION
## Phase 1f — trade modal follow-up

Owner playtest call on the tabbed modal that shipped in #40: **buy or sell should close the modal immediately** — the updated table row (wallet count, avg, holding dot) is the feedback, not a lingering panel. ✕ and Escape remain for backing out without trading.

- `TradeModal`: both execute handlers dispatch, play their sound, and close
- E2E flows updated for the new rhythm: multi-step trades reopen from the market or holdings row (which also exercises the Sell-tab entry point); the both-tabs axe scan reopens via the holdings row
- ROADMAP F2 iteration note updated

56 unit / 27 E2E green; behavior verified in-browser (buy closes → holdings row reopens on Sell → sell closes, wallet back to 0).

*Process note: this was built as a follow-up commit to #40, which got merged mid-flight — cherry-picked onto a fresh branch off main, and the accidentally recreated `claude/ux-sweep-2` branch was deleted.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)