### PR TITLE
feat(1f): close out the UX sweep — density, hierarchy, resizeable panels, music

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "static-export",
       "runtimeExecutable": "npx",
       "runtimeArgs": ["serve", "-s", "dist", "-l", "3000"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": false
     }
   ]
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -263,6 +263,16 @@ polish in Phase 2.
       high score + seed + gear grouped bottom-left of the sidebar, as far from
       the game as possible.
 - [x] G6: End Day gets a player-style skip icon (▸|); "reddit thread" → "post".
+- [x] G7 (round 2): receipt trimmed to one line — Cost on Buy, Proceeds on
+      Sell; the cash-after/gain arithmetic is the player's to do.
+- [x] G8 (round 2): every finished day in the activity log folds into a
+      collapsible `<details>` group under its "end of day" header (entry
+      count shown); today's entries stay streaming in the aria-live list.
+      Eventless days render as a plain marker.
+- [x] G9 (round 2): End Day's skip icon drawn as an inline SVG instead of
+      two kerned text characters; settings toggles aligned (CRT label loses
+      its parenthetical), How to play grouped with the other buttons below
+      the divider; the sidebar gear is borderless and bigger.
 
 *D. Controls polish*
 - [x] D1: "max" placeholder next to a "MAX" button reads as a stutter — pick one.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -273,6 +273,9 @@ polish in Phase 2.
       two kerned text characters; settings toggles aligned (CRT label loses
       its parenthetical), How to play grouped with the other buttons below
       the divider; the sidebar gear is borderless and bigger.
+- [x] G10 (round 3): Reset high scores moved above How to play in the
+      settings menu and de-glowed (quiet red, not a headline CTA); the
+      empty-state high-score line trimmed to "No high score yet".
 
 *D. Controls polish*
 - [x] D1: "max" placeholder next to a "MAX" button reads as a stutter — pick one.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,7 +171,7 @@ touch the same layout-heavy components (`AssetTable`, `GameSidebar`, `Game`).
       don't count toward the score. Both modals reachable from the sidebar and
       covered by axe scans + E2E (toggles persist across reload).
 
-## Phase 1f — Comprehensive UX sweep (NEXT UP)
+## Phase 1f — Comprehensive UX sweep ✅ (done — PRs #39, #40, #41, #42, + close-out PR)
 
 The layout is *responsive* after 1d, but the moment-to-moment experience is rough
 (owner verdict 2026-07-03: "the UI is definitely responsive, but the UX is awful").
@@ -190,11 +190,15 @@ polish in Phase 2.
 - [x] B1: Cash/Debt/Days chips sit at the very bottom, far from decisions — after
       buying, **cash isn't visible anywhere on the mobile screen**. Promote to a
       compact status bar near the market (pinned/top on mobile).
-- [ ] B2: NET WORTH panel is the largest element in the game and screams alarming
+- [x] B2: NET WORTH panel is the largest element in the game and screams alarming
       red for any negative value — even right after a fair-value buy when −$X is
-      just the debt. Shrink to a stat row; save red for *drops*.
-- [ ] B3: Mobile stacking order: a full screen of portfolio stats precedes the
-      market. Market + actions first; portfolio second.
+      just the debt. Now a stat row: green when up, calm neutral when down (no
+      colored panels).
+- [x] B3: Mobile stacking order: a full screen of portfolio stats preceded the
+      market. Market + actions now come first on phones, portfolio second — and
+      the sidebar holdings panel doesn't render below `md` at all (the market
+      table already carries dot/avg/qty and its rows open the trade modal on
+      Sell; the panel was pure duplication).
 - [x] B4: NEW GAME (destructive!) is the most prominent button on screen, no
       confirm. Demote + confirm.
 - [x] B5: Adv Day — the game's core verb — is the smallest control, buried in the
@@ -206,8 +210,12 @@ polish in Phase 2.
       price in the engine, show day-over-day Δ%+arrow per row; ties the news
       events to visible moves.
 - [x] C2: AVG. PRICE column shows $0 for coins you don't hold — render “—”.
-- [ ] C3: Log noise: `====` separators (including two adjacent for empty days)
-      drown signal; no visual hierarchy between trades and market events.
+- [x] C3: Log noise: `====` separators (including two adjacent for empty days)
+      drowned signal; no visual hierarchy between trades and market events.
+      Presentation-only fix (save format untouched): market events read
+      bright (moonshots green, crashes red-edged), your own trades read
+      quiet, day boundaries are thin centered markers and empty-day
+      duplicates collapse to one.
 
 *F. PR-2 scope from the owner's phone playtest (2026-07-17): the build is
 "pretty good so far" — two related items remain:*
@@ -248,12 +256,15 @@ polish in Phase 2.
 *E. Odds & ends*
 - [x] E1: Empty high-score state renders a stray "—" + "SET A RECORD THIS RUN!"
       widow.
-- [ ] E2: "+0.0%" in green immediately after every buy — noise.
-- [ ] E3: Desktop: log capped at ~3 lines while half the screen is dead space.
-- [ ] E4: Resizeable sections on desktop (owner request 2026-07-17) — drag
-      dividers between sidebar / activity log / market so players allocate
-      screen space to what they care about (log readers vs. table watchers).
-      Pairs naturally with E3; persist sizes in settings, not game state.
+- [x] E2: "+0.0%" in green immediately after every buy — noise. Near-zero
+      position deltas (<0.05%) now render nothing, in the holdings rows and
+      the trade modal both.
+- [x] E3: Desktop: log capped at ~3 lines while half the screen was dead
+      space. Default desktop log height is now 40vh, resizable (E4).
+- [x] E4: Resizeable sections on desktop (owner request 2026-07-17) — drag
+      dividers between sidebar / content and log / market (pointer drag +
+      arrow keys, `role="separator"` with value semantics). Sizes persist
+      in settings, not game state.
 - [x] E5: Removed the invisible 1×1 `#testMode` button from the difficulty modal.
       It shipped to production, was keyboard-focusable, and announced "Enable test
       mode" to screen readers; a leftover Cypress hook from PR #5 that the E2E
@@ -261,8 +272,12 @@ polish in Phase 2.
       `lib/state/modes.ts` stays: unit tests and the reducer's high-score gating
       use it, and DEV-gating it would break the `Record<State['mode'], …>`
       contract and crash restored old Test-mode saves.
-- [ ] Landing page menu stubs (PROFILES/CREDITS "SOON") — ship or cut.
-- [ ] Background music (deferred from 1e — needs a real track or a decent loop).
+- [x] Landing page menu stubs (PROFILES/CREDITS "SOON") — cut; Credits returns
+      as a real page in Phase 2 (font attribution).
+- [x] Background music: sparse generative chiptune loop, synthesized with Web
+      Audio like the SFX (no assets). Off by default — it's a taste thing —
+      with a Settings toggle; when pre-enabled it starts on the first
+      interaction (autoplay policy).
 
 ## Phase 2 — Web release (v1.0 on cryptofrenzy.live)
 
@@ -328,7 +343,7 @@ Roughly in order of value-for-effort:
 |---|---|---|
 | Mobile support in v1 | Full responsive vs. desktop-only gate | Responsive — it's a web game, half your traffic will be phones |
 | Trade entry points (owner, 2026-07-16) | Row tap → tabbed modal (current) vs. per-row Buy/Sell buttons → single-purpose modals | Ship tabs, playtest; row buttons re-add controls the slim table just shed (mobile width), and owner suspects they'd fracture the experience |
-| Sidebar holdings panel on mobile | Keep vs. drop (market table already shows dot/avg/qty) | Fold into B2/B3 in 1f PR 3 — leaning drop or collapse on phones |
+| ~~Sidebar holdings panel on mobile~~ | Keep vs. drop (market table already shows dot/avg/qty) | **Resolved 2026-07-17 (1f PR 3): dropped below `md`** — pure duplication of the table |
 | Backend for leaderboards | None (local only) vs. serverless (Vercel KV/Postgres, Supabase) | Ship v1.0 with no backend; add serverless leaderboard in Phase 4 |
 | macOS signing | $99/yr Apple Developer vs. unsigned (users must right-click-open) | Pay it if desktop is serious; skip for itch.io-only |
 | Windows signing | Cert (~$200+/yr) vs. unsigned (SmartScreen warning) | Ship unsigned initially; revisit on traction |
@@ -337,6 +352,6 @@ Roughly in order of value-for-effort:
 
 ## Suggested sequencing
 
-Phases 0–1e are shipped. Next is 1f (comprehensive UX sweep — inventory by
+Phases 0–1f are shipped. Next is Phase 2 (web release). Historical note — 1f ran as: inventory by
 playing real runs on phone + desktop, then fix). Phase 2 is a weekend. Phase 3 is a weekend plus signing paperwork
 latency. Phase 4 is open-ended, one feature at a time.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,6 +246,24 @@ polish in Phase 2.
       row is the feedback. Done replaced by a ✕ dismiss in the corner,
       clear button is a ✕ icon, AVG. PRICE header shortened to AVG.
 
+*G. Post-close-out polish playtest (owner notes, 2026-07-17)*
+- [x] G1: Trade modal reads like a receipt: player stats stacked left-aligned
+      (cash / wallet space / holding) with more air under the asset price, and
+      live totals above the execute button — Cost + Cash-after on Buy,
+      Proceeds + Gain on Sell — so the decision is priced before committing.
+      All slots render on both tabs (blank space beats layout jumps); top
+      padding trimmed; ✕ dismiss borderless.
+- [x] G2: Stepper regrouped to `(Max)  (−)(+)  [n]` — the clear-to-zero ✕
+      button cut (typing 0 does the same job).
+- [x] G3: "Need $X cash" → "Ins. funds".
+- [x] G4: AVG column cut from the market table — cost basis lives in the
+      holdings panel and the trade modal; the market table is about the market.
+- [x] G5: Meta out of the gameplay loop: How to play, Abandon run (tap-again
+      confirm intact) moved into the settings menu behind a single ⚙ icon;
+      high score + seed + gear grouped bottom-left of the sidebar, as far from
+      the game as possible.
+- [x] G6: End Day gets a player-style skip icon (▸|); "reddit thread" → "post".
+
 *D. Controls polish*
 - [x] D1: "max" placeholder next to a "MAX" button reads as a stutter — pick one.
 - [x] D2: Sell input clips its own placeholder ("al]") — width vs 16px font.

--- a/components/AssetTable.tsx
+++ b/components/AssetTable.tsx
@@ -66,15 +66,9 @@ const AssetTable = ({
             <th className="px-2 sm:px-3 py-3 text-left text-xs font-semibold text-crt-cyan uppercase tracking-wider">
               Price
             </th>
-            {/* "Avg. Price" was the widest header in the table (owner
-                playtest) — the abbreviation costs nothing next to the
-                PRICE column and buys the phone real room */}
-            <th
-              className="px-2 sm:px-3 py-3 text-left text-xs font-semibold text-crt-cyan uppercase tracking-wider"
-              title="Your average purchase price"
-            >
-              Avg
-            </th>
+            {/* No AVG column (owner call, 2026-07-17): your cost basis
+                lives in the holdings panel and the trade modal — the
+                market table is about the market */}
             <th className="px-2 sm:px-3 py-3 text-right text-xs font-semibold text-crt-cyan uppercase tracking-wider">
               Wallet
             </th>
@@ -139,14 +133,6 @@ const AssetTable = ({
                       asset.previousPrice,
                     )}
                   </div>
-                </td>
-                <td
-                  className="px-2 sm:px-3 py-3 text-sm text-white/80"
-                  data-cy="assetAveragePrice"
-                >
-                  {asset.wallet > 0
-                    ? `$${numberWithCommas(asset.averageCost)}`
-                    : '—'}
                 </td>
                 <td
                   className="px-2 sm:px-3 py-3 text-sm text-right text-crt-cyan font-medium"

--- a/components/Divider.tsx
+++ b/components/Divider.tsx
@@ -1,0 +1,81 @@
+import { useRef } from 'react';
+
+/**
+ * A draggable panel divider (1f E4, owner request): drag to reallocate
+ * screen space, arrow keys for keyboard users. The parent owns the
+ * value and persists it in settings — layout is a device preference,
+ * not game state.
+ */
+const Divider = ({
+  orientation,
+  value,
+  min,
+  max,
+  onChange,
+  label,
+  dataCy,
+}: {
+  /** "vertical" separates side-by-side panels (drag left/right) */
+  orientation: 'vertical' | 'horizontal';
+  value: number;
+  min: number;
+  max: number;
+  onChange: (next: number) => void;
+  label: string;
+  dataCy: string;
+}) => {
+  const dragStart = useRef<{ pos: number; value: number } | null>(
+    null,
+  );
+  const clamp = (n: number) => Math.min(max, Math.max(min, n));
+  const isVertical = orientation === 'vertical';
+
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      aria-label={label}
+      aria-valuenow={Math.round(value)}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      tabIndex={0}
+      data-cy={dataCy}
+      onPointerDown={(e) => {
+        dragStart.current = {
+          pos: isVertical ? e.clientX : e.clientY,
+          value,
+        };
+        e.currentTarget.setPointerCapture(e.pointerId);
+      }}
+      onPointerMove={(e) => {
+        if (!dragStart.current) return;
+        const pos = isVertical ? e.clientX : e.clientY;
+        onChange(
+          clamp(dragStart.current.value + pos - dragStart.current.pos),
+        );
+      }}
+      onPointerUp={() => {
+        dragStart.current = null;
+      }}
+      onKeyDown={(e) => {
+        const step =
+          e.key === (isVertical ? 'ArrowRight' : 'ArrowDown')
+            ? 16
+            : e.key === (isVertical ? 'ArrowLeft' : 'ArrowUp')
+              ? -16
+              : 0;
+        if (step !== 0) {
+          e.preventDefault();
+          onChange(clamp(value + step));
+        }
+      }}
+      className={
+        isVertical
+          ? 'w-1.5 shrink-0 cursor-col-resize self-stretch bg-white/5 hover:bg-crt-cyan/40 focus-visible:bg-crt-cyan/60 transition-colors touch-none'
+          : 'h-1.5 shrink-0 cursor-row-resize w-full bg-white/5 hover:bg-crt-cyan/40 focus-visible:bg-crt-cyan/60 rounded transition-colors touch-none'
+      }
+    />
+  );
+};
+
+export default Divider;

--- a/components/GameSidebar.tsx
+++ b/components/GameSidebar.tsx
@@ -165,9 +165,7 @@ const GameSidebar = ({
             High Score: ${numberWithCommas(state.highScore!)}
           </p>
         ) : (
-          <p className="text-xs text-white/50">
-            No high score yet — set a record this run!
-          </p>
+          <p className="text-xs text-white/50">No high score yet</p>
         )}
 
         {state.seed > 0 && (

--- a/components/GameSidebar.tsx
+++ b/components/GameSidebar.tsx
@@ -75,83 +75,94 @@ const GameSidebar = ({
 
   return (
     <aside className="w-full min-w-0 flex flex-col gap-6">
-      <h2 className="text-2xl text-white/90 font-semibold tracking-wide">
-        NET WORTH
-      </h2>
-      <div
-        className={cn(
-          'panel-crt rounded-lg p-3 h-40 text-right flex flex-col justify-center',
-          netWorth >= 0 && 'bg-crt-transparentGreen',
-          netWorth < 0 && 'bg-crt-transparentRed',
-        )}
-      >
-        <div
+      {/* B2: a stat row, not a billboard — the giant colored panel
+          dominated the screen and its red state read as an alarm when
+          it was just the starting debt. Green celebrates being up;
+          being down renders calm and neutral. */}
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-sm text-white/60 font-semibold tracking-widest uppercase">
+          Net worth
+        </h2>
+        <span
+          data-cy="netWorth"
           className={cn(
-            'text-7xl font-bold text-white/90 break-all',
-            netWorth >= 0 && 'text-crt-green',
-            netWorth < 0 && 'text-crt-red',
+            'text-3xl font-bold',
+            netWorth > 0 ? 'text-crt-green' : 'text-white/90',
           )}
         >
           {formatMoney(netWorth)}
-        </div>
+        </span>
       </div>
 
-      <h2 className="text-2xl text-white/90 font-semibold tracking-wide">
-        HOLDINGS
-      </h2>
+      {/* B3: hidden on phones — the market table already carries the
+          position (dot, avg, count) and its rows open the same modal
+          on the Sell tab, so this panel was a full screen of
+          duplicate stats standing between the player and the market. */}
+      <div className="hidden md:flex flex-col gap-3">
+        <h2 className="text-sm text-white/60 font-semibold tracking-widest uppercase">
+          Holdings
+        </h2>
 
-      {holdings.length === 0 ? (
-        <div className="panel-crt rounded-lg py-5 text-center text-crt-yellow text-sm">
-          No current holdings
-        </div>
-      ) : (
-        // Display-only: selling happens in the TradeModal (tap a row).
-        <div className="panel-crt rounded-lg divide-y divide-white/10 overflow-y-auto max-h-[40vh]">
-          {holdings.map(([key, asset]) => {
-            const pct =
-              asset.averageCost > 0
-                ? ((asset.price - asset.averageCost) /
-                    asset.averageCost) *
-                  100
-                : 0;
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => onSelectAsset(key)}
-                aria-label={`Trade ${asset.name}`}
-                className="w-full p-3 flex items-center justify-between text-sm text-white/90 hover:bg-white/5 text-left"
-                data-cy={`${key}HoldingRow`}
-              >
-                <span className="font-medium text-crt-cyan">
-                  {asset.symbol}
-                </span>
-                <span className="flex items-center gap-3">
-                  <span className="text-white/70">
-                    avg ${numberWithCommas(asset.averageCost)}
+        {holdings.length === 0 ? (
+          <div className="panel-crt rounded-lg py-5 text-center text-crt-yellow text-sm">
+            No current holdings
+          </div>
+        ) : (
+          // Display-only: selling happens in the TradeModal (tap a row).
+          <div className="panel-crt rounded-lg divide-y divide-white/10 overflow-y-auto max-h-[40vh]">
+            {holdings.map(([key, asset]) => {
+              const pct =
+                asset.averageCost > 0
+                  ? ((asset.price - asset.averageCost) /
+                      asset.averageCost) *
+                    100
+                  : 0;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => onSelectAsset(key)}
+                  aria-label={`Trade ${asset.name}`}
+                  className="w-full p-3 flex items-center justify-between text-sm text-white/90 hover:bg-white/5 text-left"
+                  data-cy={`${key}HoldingRow`}
+                >
+                  <span className="font-medium text-crt-cyan">
+                    {asset.symbol}
                   </span>
-                  <span
-                    className={cn(
-                      pct >= 0 && 'text-crt-green',
-                      pct < 0 && 'text-crt-red',
+                  <span className="flex items-center gap-3">
+                    <span className="text-white/70">
+                      avg ${numberWithCommas(asset.averageCost)}
+                    </span>
+                    {/* E2: a freshly bought coin is ±0.0% — show
+                        nothing rather than a celebratory green zero */}
+                    {Math.abs(pct) >= 0.05 && (
+                      <span
+                        className={cn(
+                          pct > 0 && 'text-crt-green',
+                          pct < 0 && 'text-crt-red',
+                        )}
+                      >
+                        {pct > 0 ? '+' : ''}
+                        {pct.toFixed(1)}%
+                      </span>
                     )}
-                  >
-                    {pct >= 0 ? '+' : ''}
-                    {pct.toFixed(1)}%
+                    <span>× {asset.wallet}</span>
+                    <span
+                      className="text-crt-cyan/60"
+                      aria-hidden="true"
+                    >
+                      ›
+                    </span>
                   </span>
-                  <span>× {asset.wallet}</span>
-                  <span className="text-crt-cyan/60" aria-hidden="true">
-                    ›
-                  </span>
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
 
-      <h2 className="text-2xl text-white/90 font-semibold tracking-wide">
-        WALLET
+      <h2 className="text-sm text-white/60 font-semibold tracking-widest uppercase">
+        Wallet
       </h2>
       <Chip
         figure={`${state.wallet.amount}/${state.wallet.capacity}`}

--- a/components/GameSidebar.tsx
+++ b/components/GameSidebar.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useRef, useState } from 'react';
+import { Dispatch } from 'react';
 import { State, Action } from '../lib/types';
 import {
   computeNetWorth,
@@ -7,8 +7,6 @@ import {
   seedShareUrl,
 } from '../helpers/utils';
 import { cn } from '../lib/cn';
-import { clearSave } from '../lib/state/persistence';
-import { loadHighScore } from '../lib/state/highScores';
 import { useNotification } from '../lib/NotificationContext';
 import Chip from './Chip';
 
@@ -16,39 +14,14 @@ const GameSidebar = ({
   state,
   dispatch,
   onOpenSettings,
-  onOpenHelp,
   onSelectAsset,
 }: {
   state: State;
   dispatch: Dispatch<Action>;
   onOpenSettings: () => void;
-  onOpenHelp: () => void;
   onSelectAsset: (assetKey: string) => void;
 }) => {
   const { showNotification } = useNotification();
-
-  // NEW GAME wipes the run — require a second tap within 3s to confirm
-  const [confirmingReset, setConfirmingReset] = useState(false);
-  const confirmTimer = useRef<ReturnType<typeof setTimeout>>();
-
-  const handleNewGame = () => {
-    if (!confirmingReset) {
-      setConfirmingReset(true);
-      clearTimeout(confirmTimer.current);
-      confirmTimer.current = setTimeout(
-        () => setConfirmingReset(false),
-        3000,
-      );
-      return;
-    }
-    clearTimeout(confirmTimer.current);
-    setConfirmingReset(false);
-    clearSave();
-    dispatch({
-      type: 'INIT',
-      payload: { highScore: loadHighScore(state.mode) },
-    });
-  };
 
   const copySeedLink = () => {
     navigator.clipboard
@@ -74,7 +47,7 @@ const GameSidebar = ({
     state.currentDay > 0 && state.cash >= state.wallet.expansionCost;
 
   return (
-    <aside className="w-full min-w-0 flex flex-col gap-6">
+    <aside className="w-full min-w-0 h-full flex flex-col gap-6">
       {/* B2: a stat row, not a billboard — the giant colored panel
           dominated the screen and its red state read as an alarm when
           it was just the starting debt. Green celebrates being up;
@@ -181,65 +154,45 @@ const GameSidebar = ({
         }}
       />
 
-      {state.seed > 0 && (
-        <button
-          type="button"
-          onClick={copySeedLink}
-          className="text-xs text-white/50 hover:text-crt-cyan text-left tracking-wider"
-          data-cy="seedDisplay"
-          title="Copy a link that replays this exact market"
-        >
-          MARKET SEED: {state.seed} ⧉
-        </button>
-      )}
+      {/* Meta, not gameplay (owner call, 2026-07-17): everything that
+          isn't the core loop — help, settings, abandoning, records —
+          lives bottom-left, as far from the game as it gets. The gear
+          opens the settings menu, which now also holds How to play
+          and Abandon run. */}
+      <div className="mt-auto pt-4 flex flex-col items-start gap-2">
+        {hasHighScore ? (
+          <p className="text-xs text-crt-green/80">
+            High Score: ${numberWithCommas(state.highScore!)}
+          </p>
+        ) : (
+          <p className="text-xs text-white/50">
+            No high score yet — set a record this run!
+          </p>
+        )}
 
-      <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={onOpenHelp}
-          className="btn flex-1 py-2 px-3 text-xs font-semibold"
-          id="openHowToPlay"
-        >
-          How to play
-        </button>
+        {state.seed > 0 && (
+          <button
+            type="button"
+            onClick={copySeedLink}
+            className="text-xs text-white/50 hover:text-crt-cyan text-left tracking-wider"
+            data-cy="seedDisplay"
+            title="Copy a link that replays this exact market"
+          >
+            MARKET SEED: {state.seed} ⧉
+          </button>
+        )}
+
         <button
           type="button"
           onClick={onOpenSettings}
-          className="btn flex-1 py-2 px-3 text-xs font-semibold"
+          className="btn px-3 py-2"
           id="openSettings"
+          aria-label="Settings & help"
+          title="Settings, how to play, abandon run"
         >
-          Settings
+          <span aria-hidden="true">⚙</span>
         </button>
       </div>
-
-      {hasHighScore ? (
-        <p className="text-lg font-bold text-crt-green">
-          High Score: ${numberWithCommas(state.highScore!)}
-        </p>
-      ) : (
-        <p className="text-xs text-white/70">
-          No high score yet — set a record this run!
-        </p>
-      )}
-
-      {/* Demoted from the most prominent button on screen: it wipes the
-          run, so it reads quiet and asks for a second tap to confirm. */}
-      <button
-        type="button"
-        onClick={handleNewGame}
-        className={cn(
-          'text-left text-xs tracking-wider py-1',
-          confirmingReset
-            ? 'text-crt-red font-semibold'
-            : 'text-white/50 hover:text-crt-red',
-        )}
-        id="runInfo"
-        title="Abandon this run and start over"
-      >
-        {confirmingReset
-          ? '⚠ TAP AGAIN TO ABANDON THIS RUN'
-          : 'ABANDON RUN / NEW GAME'}
-      </button>
     </aside>
   );
 };

--- a/components/GameSidebar.tsx
+++ b/components/GameSidebar.tsx
@@ -185,7 +185,7 @@ const GameSidebar = ({
         <button
           type="button"
           onClick={onOpenSettings}
-          className="btn px-3 py-2"
+          className="text-3xl leading-none text-white/60 hover:text-crt-cyan py-1"
           id="openSettings"
           aria-label="Settings & help"
           title="Settings, how to play, abandon run"

--- a/components/Log.tsx
+++ b/components/Log.tsx
@@ -1,38 +1,43 @@
 const SEPARATOR = /^=+ End of Day (\d+) =+$/;
 const TRADE = /^\[Day \d+\]/;
 
+type Entry = { key: number; msg: string };
+
 /**
- * The activity feed, with a visual hierarchy instead of a wall of
- * identical lines (1f C3): market events read bright, your own trades
- * read quiet, day boundaries are thin markers instead of `====` walls
- * (and empty days collapse into one marker instead of stacking two).
+ * The activity feed. Today's entries stream into an aria-live list;
+ * every finished day folds into a collapsible <details> group under
+ * its "end of day" header (owner note, 2026-07-17) — history is one
+ * tap away instead of a wall of text. Market events read bright,
+ * moonshots green, crashes red-edged, your own trades quiet.
  *
  * Height: phones get a fixed slice; on desktop the panel is sized by
- * the --log-h variable so the drag divider in Game can resize it (E4)
- * instead of capping it at three lines above dead space (E3).
+ * the --log-h variable so the drag divider in Game can resize it.
  */
 const Log = ({ log }: { log: string[] }) => {
   // Entries are prepended (newest first) and never reordered or
   // removed, so keying from the end of the array gives each message a
-  // stable identity. Index-based keys would make React mutate every
-  // existing <li>'s text on each update instead of inserting one new
-  // node — with aria-live that would re-announce the whole log on
-  // every day advance.
-  const items: { key: number; msg: string }[] = log.map(
-    (msg, idx) => ({ key: log.length - 1 - idx, msg }),
-  );
+  // stable identity — in the live region, index keys would re-announce
+  // the whole list on every update.
+  const entries: Entry[] = log.map((msg, idx) => ({
+    key: log.length - 1 - idx,
+    msg,
+  }));
 
-  // Collapse runs of day separators (an eventless day stacks two in a
-  // row): keep only the first of each run — newest first, so that's
-  // the latest day boundary.
-  const visible = items.filter(
-    ({ msg }, idx) =>
-      !(
-        SEPARATOR.test(msg) &&
-        idx > 0 &&
-        SEPARATOR.test(items[idx - 1].msg)
-      ),
-  );
+  // Group: everything above the first separator is today; each
+  // separator starts the (finished) day it names, holding the entries
+  // that follow it in the array.
+  const today: Entry[] = [];
+  const days: { day: string; key: number; items: Entry[] }[] = [];
+  for (const entry of entries) {
+    const match = entry.msg.match(SEPARATOR);
+    if (match) {
+      days.push({ day: match[1], key: entry.key, items: [] });
+    } else if (days.length > 0) {
+      days[days.length - 1].items.push(entry);
+    } else {
+      today.push(entry);
+    }
+  }
 
   const lineClass = (msg: string): string => {
     if (msg.includes('MOONSHOT'))
@@ -46,35 +51,77 @@ const Log = ({ log }: { log: string[] }) => {
     return 'border-l-2 border-crt-cyan/50 pl-3 py-0.5';
   };
 
+  const renderItems = (items: Entry[]) =>
+    items.map(({ key, msg }) => (
+      <li key={key} className={lineClass(msg)}>
+        {msg}
+      </li>
+    ));
+
   return (
     <>
       <h2 className="text-sm text-white/60 font-semibold tracking-widest uppercase">
         Activity
       </h2>
       <div className="panel-crt rounded-lg p-4">
-        <ul
-          className="space-y-1.5 text-sm h-[15vh] lg:h-[var(--log-h,40vh)] overflow-y-auto text-white/90"
-          aria-live="polite"
-          aria-atomic="false"
+        <div
+          className="h-[15vh] lg:h-[var(--log-h,40vh)] overflow-y-auto space-y-1.5 text-sm text-white/90"
+          role="region"
           aria-label="Activity log"
           tabIndex={0}
         >
-          {visible.map(({ key, msg }) => {
-            const day = msg.match(SEPARATOR);
-            return day ? (
-              <li
-                key={key}
-                className="text-crt-cyan/40 text-xs uppercase tracking-widest text-center py-1"
-              >
-                — end of day {day[1]} —
+          <ul
+            className="space-y-1.5"
+            aria-live="polite"
+            aria-atomic="false"
+            aria-label="Latest events"
+          >
+            {renderItems(today)}
+            {/* Screen-reader-only day boundary: the visual markers
+                moved out of this live region into the fold headers
+                below, which silenced End Day entirely on eventless
+                days (live regions announce additions; the fold is a
+                removal). The newest marker rides along here — keyed
+                by its log entry, so each day announces exactly once. */}
+            {days.length > 0 && (
+              <li key={days[0].key} className="sr-only">
+                End of day {days[0].day}
               </li>
+            )}
+          </ul>
+          {days.map(({ day, key, items }) =>
+            items.length > 0 ? (
+              <details key={key} className="group">
+                {/* /70 resting, not /40: this is an interactive
+                    control now and the dimmer tint fell below WCAG
+                    contrast — which the axe gate can't catch here
+                    (the CRT overlay makes axe mark contrast checks
+                    incomplete rather than failed) */}
+                <summary className="list-none [&::-webkit-details-marker]:hidden cursor-pointer text-crt-cyan/70 hover:text-crt-cyan text-xs uppercase tracking-widest text-center py-1 select-none">
+                  <span
+                    className="inline-block mr-1.5 transition-transform group-open:rotate-90"
+                    aria-hidden="true"
+                  >
+                    ▸
+                  </span>
+                  end of day {day} · {items.length}
+                  <span className="sr-only"> entries</span>
+                </summary>
+                <ul className="space-y-1.5 pt-1">
+                  {renderItems(items)}
+                </ul>
+              </details>
             ) : (
-              <li key={key} className={lineClass(msg)}>
-                {msg}
-              </li>
-            );
-          })}
-        </ul>
+              // A day where nothing happened: just the marker
+              <p
+                key={key}
+                className="text-crt-cyan/60 text-xs uppercase tracking-widest text-center py-1"
+              >
+                — end of day {day} —
+              </p>
+            ),
+          )}
+        </div>
       </div>
     </>
   );

--- a/components/Log.tsx
+++ b/components/Log.tsx
@@ -1,31 +1,79 @@
+const SEPARATOR = /^=+ End of Day (\d+) =+$/;
+const TRADE = /^\[Day \d+\]/;
+
+/**
+ * The activity feed, with a visual hierarchy instead of a wall of
+ * identical lines (1f C3): market events read bright, your own trades
+ * read quiet, day boundaries are thin markers instead of `====` walls
+ * (and empty days collapse into one marker instead of stacking two).
+ *
+ * Height: phones get a fixed slice; on desktop the panel is sized by
+ * the --log-h variable so the drag divider in Game can resize it (E4)
+ * instead of capping it at three lines above dead space (E3).
+ */
 const Log = ({ log }: { log: string[] }) => {
+  // Entries are prepended (newest first) and never reordered or
+  // removed, so keying from the end of the array gives each message a
+  // stable identity. Index-based keys would make React mutate every
+  // existing <li>'s text on each update instead of inserting one new
+  // node — with aria-live that would re-announce the whole log on
+  // every day advance.
+  const items: { key: number; msg: string }[] = log.map(
+    (msg, idx) => ({ key: log.length - 1 - idx, msg }),
+  );
+
+  // Collapse runs of day separators (an eventless day stacks two in a
+  // row): keep only the first of each run — newest first, so that's
+  // the latest day boundary.
+  const visible = items.filter(
+    ({ msg }, idx) =>
+      !(
+        SEPARATOR.test(msg) &&
+        idx > 0 &&
+        SEPARATOR.test(items[idx - 1].msg)
+      ),
+  );
+
+  const lineClass = (msg: string): string => {
+    if (msg.includes('MOONSHOT'))
+      return 'border-l-2 border-crt-green/60 pl-3 py-0.5 text-crt-green';
+    if (msg.startsWith('🚀'))
+      return 'border-l-2 border-crt-green/50 pl-3 py-0.5';
+    if (msg.startsWith('📉'))
+      return 'border-l-2 border-crt-red/50 pl-3 py-0.5';
+    if (TRADE.test(msg))
+      return 'border-l-2 border-white/15 pl-3 py-0.5 text-white/60';
+    return 'border-l-2 border-crt-cyan/50 pl-3 py-0.5';
+  };
+
   return (
     <>
-      <h2 className="text-2xl text-white/90 font-semibold tracking-wide">
-        ACTIVITY
+      <h2 className="text-sm text-white/60 font-semibold tracking-widest uppercase">
+        Activity
       </h2>
       <div className="panel-crt rounded-lg p-4">
         <ul
-          className="space-y-1.5 text-sm h-[15vh] overflow-y-auto text-white/90"
+          className="space-y-1.5 text-sm h-[15vh] lg:h-[var(--log-h,40vh)] overflow-y-auto text-white/90"
           aria-live="polite"
           aria-atomic="false"
           aria-label="Activity log"
           tabIndex={0}
         >
-          {log.map((msg, idx) => (
-            // Entries are prepended (newest first) and never reordered
-            // or removed, so keying from the end of the array gives each
-            // message a stable identity. Index-based keys would make
-            // React mutate every existing <li>'s text on each update
-            // instead of inserting one new node — with aria-live that
-            // would re-announce the whole log on every day advance.
-            <li
-              key={log.length - 1 - idx}
-              className="border-l-2 border-crt-cyan/50 pl-3 py-0.5"
-            >
-              {msg}
-            </li>
-          ))}
+          {visible.map(({ key, msg }) => {
+            const day = msg.match(SEPARATOR);
+            return day ? (
+              <li
+                key={key}
+                className="text-crt-cyan/40 text-xs uppercase tracking-widest text-center py-1"
+              >
+                — end of day {day[1]} —
+              </li>
+            ) : (
+              <li key={key} className={lineClass(msg)}>
+                {msg}
+              </li>
+            );
+          })}
         </ul>
       </div>
     </>

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { useSettings } from '../lib/SettingsContext';
 import { clearHighScores } from '../lib/state/highScores';
 import { useNotification } from '../lib/NotificationContext';
@@ -34,9 +35,41 @@ const Toggle = ({
   </div>
 );
 
-const Settings = ({ onClose }: { onClose: () => void }) => {
+/**
+ * The meta menu (owner call, 2026-07-17): everything that isn't the
+ * core gameplay loop lives here behind the sidebar's gear icon —
+ * preferences, How to play, high-score reset, and abandoning the run.
+ */
+const Settings = ({
+  onClose,
+  onOpenHelp,
+  onAbandonRun,
+}: {
+  onClose: () => void;
+  onOpenHelp: () => void;
+  onAbandonRun: () => void;
+}) => {
   const { settings, update } = useSettings();
   const { showNotification } = useNotification();
+
+  // Abandoning wipes the run — require a second tap within 3s
+  const [confirmingReset, setConfirmingReset] = useState(false);
+  const confirmTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleAbandon = () => {
+    if (!confirmingReset) {
+      setConfirmingReset(true);
+      clearTimeout(confirmTimer.current);
+      confirmTimer.current = setTimeout(
+        () => setConfirmingReset(false),
+        3000,
+      );
+      return;
+    }
+    clearTimeout(confirmTimer.current);
+    setConfirmingReset(false);
+    onAbandonRun();
+  };
 
   const handleResetScores = () => {
     clearHighScores();
@@ -89,7 +122,19 @@ const Settings = ({ onClose }: { onClose: () => void }) => {
           />
         </div>
 
-        <div className="border-t border-white/10 pt-4">
+        <button
+          type="button"
+          id="openHowToPlay"
+          onClick={() => {
+            onClose();
+            onOpenHelp();
+          }}
+          className="btn w-full py-2 text-sm"
+        >
+          How to play
+        </button>
+
+        <div className="border-t border-white/10 pt-4 space-y-3">
           <button
             type="button"
             id="resetScores"
@@ -97,6 +142,22 @@ const Settings = ({ onClose }: { onClose: () => void }) => {
             className="btn btn-danger w-full py-2 text-sm"
           >
             Reset high scores
+          </button>
+          <button
+            type="button"
+            id="runInfo"
+            onClick={handleAbandon}
+            className={cn(
+              'btn w-full py-2 text-sm',
+              confirmingReset
+                ? 'btn-danger font-semibold'
+                : 'text-white/60 border-white/20 hover:text-crt-red hover:border-crt-red/60',
+            )}
+            title="Abandon this run and start over"
+          >
+            {confirmingReset
+              ? '⚠ TAP AGAIN TO ABANDON THIS RUN'
+              : 'ABANDON RUN / NEW GAME'}
           </button>
         </div>
 

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -123,6 +123,16 @@ const Settings = ({
         </div>
 
         <div className="border-t border-white/10 pt-4 space-y-3">
+          {/* Reset is not a headline CTA — quiet red, no glow — and sits
+              above How to play (owner call, 2026-07-17) */}
+          <button
+            type="button"
+            id="resetScores"
+            onClick={handleResetScores}
+            className="btn w-full py-2 text-sm text-crt-red border-crt-red/40"
+          >
+            Reset high scores
+          </button>
           <button
             type="button"
             id="openHowToPlay"
@@ -133,14 +143,6 @@ const Settings = ({
             className="btn w-full py-2 text-sm"
           >
             How to play
-          </button>
-          <button
-            type="button"
-            id="resetScores"
-            onClick={handleResetScores}
-            className="btn btn-danger w-full py-2 text-sm"
-          >
-            Reset high scores
           </button>
           <button
             type="button"

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -76,6 +76,12 @@ const Settings = ({ onClose }: { onClose: () => void }) => {
             onChange={(sound) => update({ sound })}
           />
           <Toggle
+            id="musicToggle"
+            label="Background music"
+            checked={settings.music}
+            onChange={(music) => update({ music })}
+          />
+          <Toggle
             id="crtToggle"
             label="CRT effects (scanlines, glow)"
             checked={settings.crt}

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -116,25 +116,24 @@ const Settings = ({
           />
           <Toggle
             id="crtToggle"
-            label="CRT effects (scanlines, glow)"
+            label="CRT effects"
             checked={settings.crt}
             onChange={(crt) => update({ crt })}
           />
         </div>
 
-        <button
-          type="button"
-          id="openHowToPlay"
-          onClick={() => {
-            onClose();
-            onOpenHelp();
-          }}
-          className="btn w-full py-2 text-sm"
-        >
-          How to play
-        </button>
-
         <div className="border-t border-white/10 pt-4 space-y-3">
+          <button
+            type="button"
+            id="openHowToPlay"
+            onClick={() => {
+              onClose();
+              onOpenHelp();
+            }}
+            className="btn w-full py-2 text-sm"
+          >
+            How to play
+          </button>
           <button
             type="button"
             id="resetScores"

--- a/components/StatusBar.tsx
+++ b/components/StatusBar.tsx
@@ -110,7 +110,7 @@ const StatusBar = ({
               : 'End the day: prices re-roll and debt compounds'
           }
         >
-          End Day ▸
+          End Day <span aria-hidden="true">▸|</span>
         </button>
       </div>
     </div>

--- a/components/StatusBar.tsx
+++ b/components/StatusBar.tsx
@@ -110,7 +110,21 @@ const StatusBar = ({
               : 'End the day: prices re-roll and debt compounds'
           }
         >
-          End Day <span aria-hidden="true">▸|</span>
+          <span className="inline-flex items-center gap-2">
+            End Day
+            {/* skip-to-next, drawn instead of typed: "▸|" as two text
+                characters kerned apart; one glyph like a player's
+                skip button */}
+            <svg
+              viewBox="0 0 16 16"
+              className="w-3.5 h-3.5"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M2 2l9 6-9 6z" />
+              <rect x="12.5" y="2" width="2.5" height="12" />
+            </svg>
+          </span>
         </button>
       </div>
     </div>

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useState } from 'react';
+import { Dispatch, ReactNode, useState } from 'react';
 import { State, Action } from '../lib/types';
 import { calculateMaxShares, numberWithCommas } from '../helpers/utils';
 import { cn } from '../lib/cn';
@@ -9,13 +9,15 @@ export type TradeSide = 'buy' | 'sell';
 
 /**
  * The per-asset trade surface (owner design, 2026-07-17): tap a market
- * row to trade. Third playtest iteration (2026-07-16): the combined
- * buy+sell layout made you "look all over the place to parse what to
- * do", so the modal is now tabbed — one side at a time, reading top to
- * bottom as info → playground → execute. Market rows open the Buy tab,
- * holdings rows open Sell. Both tabs' amounts survive switching.
- * Executing a trade closes the modal immediately (owner call,
- * 2026-07-16) — the updated table row is the feedback.
+ * row to trade. Reads like a receipt (owner notes, 2026-07-17): asset
+ * and price up top, then your stats stacked left-aligned (cash, wallet
+ * space, holding), Buy | Sell tabs, the quantity playground, and the
+ * live totals — cost and cash-after for buys, proceeds and gain for
+ * sells — right above the execute button, so the decision is priced
+ * before you commit. Market rows open Buy, holdings rows open Sell.
+ * Every slot renders on both tabs (blank space over layout jumps), and
+ * executing a trade closes the modal immediately — the updated table
+ * row is the feedback.
  */
 const TradeModal = ({
   assetKey,
@@ -52,7 +54,7 @@ const TradeModal = ({
     state.wallet.amount >= state.wallet.capacity
       ? 'Wallet full — upgrade capacity'
       : state.cash < asset.price
-        ? `Need $${numberWithCommas(asset.price)} cash`
+        ? 'Ins. funds'
         : undefined;
 
   const positionPct =
@@ -65,6 +67,14 @@ const TradeModal = ({
       ? ((asset.price - asset.previousPrice) / asset.previousPrice) *
         100
       : null;
+
+  // Live receipt totals, driven by the steppers
+  const cost = buy.quantity * asset.price;
+  const proceeds = sell.quantity * asset.price;
+  const gain =
+    asset.averageCost > 0
+      ? (asset.price - asset.averageCost) * sell.quantity
+      : 0;
 
   const handleBuy = () => {
     if (buy.quantity <= 0) return;
@@ -86,6 +96,17 @@ const TradeModal = ({
     onClose();
   };
 
+  const row = (
+    label: string,
+    value: ReactNode,
+    cy?: string,
+  ) => (
+    <div className="flex justify-between gap-4" data-cy={cy}>
+      <span className="text-white/50">{label}</span>
+      <span className="text-white/90">{value}</span>
+    </div>
+  );
+
   const tab = (tabSide: TradeSide, label: string) => (
     <button
       type="button"
@@ -105,6 +126,15 @@ const TradeModal = ({
     </button>
   );
 
+  const reason =
+    side === 'buy'
+      ? maxBuy <= 0
+        ? buyDisabledReason
+        : undefined
+      : asset.wallet === 0
+        ? 'Nothing held yet'
+        : undefined;
+
   return (
     <div
       className="fixed inset-0 bg-slate-900/80 backdrop-blur-sm z-10 flex items-center justify-center p-4 md:p-8"
@@ -114,7 +144,7 @@ const TradeModal = ({
       }}
     >
       <div
-        className="relative bg-black w-full max-w-md rounded-sm border border-crt-yellow box-shadow-crt p-6 space-y-5"
+        className="relative bg-black w-full max-w-md rounded-sm border border-crt-yellow box-shadow-crt px-6 pb-6 pt-4 space-y-4"
         role="dialog"
         aria-modal="true"
         aria-labelledby="tradeModalTitle"
@@ -123,60 +153,60 @@ const TradeModal = ({
         <button
           type="button"
           onClick={onClose}
-          className="absolute top-3 right-3 btn px-2.5 py-1 text-sm text-white/70"
+          className="absolute top-2 right-2 px-2 py-1 text-lg text-white/50 hover:text-white"
           id="tradeModalClose"
           aria-label="Close trade panel"
         >
           ✕
         </button>
 
-        {/* Info: everything you need to know, in one block up top */}
-        <div className="space-y-2 pr-10">
-          <div className="flex items-baseline justify-between gap-3 flex-wrap">
-            <h1
-              id="tradeModalTitle"
-              className="text-2xl font-bold text-slate-300 text-glow-crt"
-            >
-              {asset.name}{' '}
-              <span className="text-crt-cyan text-lg">
-                {asset.symbol}
-              </span>
-            </h1>
-            <span className="text-xl font-bold text-white/90">
-              ${numberWithCommas(asset.price)}
-              {dayPct !== null && Math.abs(dayPct) >= 0.05 && (
-                <span
-                  className={cn(
-                    'ml-2 text-sm',
-                    dayPct > 0 ? 'text-crt-green' : 'text-crt-red',
-                  )}
-                >
-                  {dayPct > 0 ? '▲' : '▼'}{' '}
-                  {Math.abs(dayPct).toFixed(1)}%
-                </span>
-              )}
+        <div className="flex items-baseline justify-between gap-3 flex-wrap pr-8">
+          <h1
+            id="tradeModalTitle"
+            className="text-2xl font-bold text-slate-300 text-glow-crt"
+          >
+            {asset.name}{' '}
+            <span className="text-crt-cyan text-lg">
+              {asset.symbol}
             </span>
-          </div>
-          <div className="text-xs text-white/60 uppercase tracking-wider space-y-1">
-            <div className="flex justify-between">
-              <span>
-                Cash{' '}
-                <span className="text-crt-green">
-                  ${numberWithCommas(state.cash)}
-                </span>
+          </h1>
+          <span className="text-xl font-bold text-white/90">
+            ${numberWithCommas(asset.price)}
+            {dayPct !== null && Math.abs(dayPct) >= 0.05 && (
+              <span
+                className={cn(
+                  'ml-2 text-sm',
+                  dayPct > 0 ? 'text-crt-green' : 'text-crt-red',
+                )}
+              >
+                {dayPct > 0 ? '▲' : '▼'} {Math.abs(dayPct).toFixed(1)}%
               </span>
-              <span>
-                Wallet space{' '}
-                <span className="text-crt-cyan">
-                  {state.wallet.capacity - state.wallet.amount}
-                </span>
-              </span>
-            </div>
-            {asset.wallet > 0 && (
-              <div data-cy="tradeModalPosition">
-                Holding{' '}
+            )}
+          </span>
+        </div>
+
+        {/* Your stats, stacked receipt-style — extra breathing room
+            below the price so asset info and player info read as two
+            distinct groups */}
+        <div className="pt-3 text-xs uppercase tracking-wider space-y-1.5">
+          {row(
+            'Cash',
+            <span className="text-crt-green">
+              ${numberWithCommas(state.cash)}
+            </span>,
+          )}
+          {row(
+            'Wallet space',
+            <span className="text-crt-cyan">
+              {state.wallet.capacity - state.wallet.amount}
+            </span>,
+          )}
+          {row(
+            'Holding',
+            asset.wallet > 0 ? (
+              <span data-cy="tradeModalPosition">
                 <span className="text-crt-cyan">×{asset.wallet}</span>{' '}
-                at avg ${numberWithCommas(asset.averageCost)}
+                @ ${numberWithCommas(asset.averageCost)}
                 {/* E2: suppress the green "+0.0%" right after a buy */}
                 {Math.abs(positionPct) >= 0.05 && (
                   <span
@@ -191,9 +221,11 @@ const TradeModal = ({
                     {positionPct.toFixed(1)}%
                   </span>
                 )}
-              </div>
-            )}
-          </div>
+              </span>
+            ) : (
+              <span className="text-white/40">—</span>
+            ),
+          )}
         </div>
 
         <div
@@ -205,8 +237,7 @@ const TradeModal = ({
           {tab('sell', 'Sell')}
         </div>
 
-        {/* Playground: the active side's amount, nothing else */}
-        <div id="tradePanel" role="tabpanel">
+        <div id="tradePanel" role="tabpanel" className="space-y-2">
           {side === 'buy' ? (
             <TradeStepper
               assetName={asset.name}
@@ -214,7 +245,6 @@ const TradeModal = ({
               cyPrefix={assetKey}
               control={buy}
               disabled={maxBuy <= 0}
-              disabledReason={buyDisabledReason}
             />
           ) : (
             <TradeStepper
@@ -223,14 +253,71 @@ const TradeModal = ({
               cyPrefix={`${assetKey}Sell`}
               control={sell}
               disabled={asset.wallet === 0}
-              disabledReason={
-                asset.wallet === 0 ? 'Nothing held yet' : undefined
-              }
             />
+          )}
+          {/* Fixed-height slot: present even when empty so the modal
+              doesn't jump when a reason appears */}
+          <p className="h-4 text-xs text-white/50 text-right">
+            {reason}
+          </p>
+        </div>
+
+        {/* The receipt totals: what this trade does to your money,
+            priced live from the stepper */}
+        <div className="text-xs uppercase tracking-wider space-y-1.5 border-t border-white/10 pt-3">
+          {side === 'buy' ? (
+            <>
+              {row(
+                'Cost',
+                cost > 0 ? (
+                  `−$${numberWithCommas(cost)}`
+                ) : (
+                  <span className="text-white/40">—</span>
+                ),
+                'tradeCost',
+              )}
+              {row(
+                'Cash after',
+                <span className="text-crt-green">
+                  ${numberWithCommas(state.cash - cost)}
+                </span>,
+                'tradeCashAfter',
+              )}
+            </>
+          ) : (
+            <>
+              {row(
+                'Proceeds',
+                proceeds > 0 ? (
+                  <span className="text-crt-green">
+                    +${numberWithCommas(proceeds)}
+                  </span>
+                ) : (
+                  <span className="text-white/40">—</span>
+                ),
+                'tradeProceeds',
+              )}
+              {row(
+                'Gain',
+                proceeds > 0 && asset.averageCost > 0 ? (
+                  <span
+                    className={cn(
+                      gain > 0 && 'text-crt-green',
+                      gain < 0 && 'text-crt-red',
+                    )}
+                  >
+                    {gain >= 0 ? '+' : '−'}$
+                    {numberWithCommas(Math.abs(gain))}
+                  </span>
+                ) : (
+                  <span className="text-white/40">—</span>
+                ),
+                'tradeGain',
+              )}
+            </>
           )}
         </div>
 
-        {/* Execute: one full-width commit for the active side */}
         {side === 'buy' ? (
           <button
             className={cn(

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -11,10 +11,10 @@ export type TradeSide = 'buy' | 'sell';
  * The per-asset trade surface (owner design, 2026-07-17): tap a market
  * row to trade. Reads like a receipt (owner notes, 2026-07-17): asset
  * and price up top, then your stats stacked left-aligned (cash, wallet
- * space, holding), Buy | Sell tabs, the quantity playground, and the
- * live totals — cost and cash-after for buys, proceeds and gain for
- * sells — right above the execute button, so the decision is priced
- * before you commit. Market rows open Buy, holdings rows open Sell.
+ * space, holding), Buy | Sell tabs, the quantity playground, and one
+ * live total — cost for buys, proceeds for sells — right above the
+ * execute button; the rest of the arithmetic is the player's.
+ * Market rows open Buy, holdings rows open Sell.
  * Every slot renders on both tabs (blank space over layout jumps), and
  * executing a trade closes the modal immediately — the updated table
  * row is the feedback.
@@ -71,10 +71,6 @@ const TradeModal = ({
   // Live receipt totals, driven by the steppers
   const cost = buy.quantity * asset.price;
   const proceeds = sell.quantity * asset.price;
-  const gain =
-    asset.averageCost > 0
-      ? (asset.price - asset.averageCost) * sell.quantity
-      : 0;
 
   const handleBuy = () => {
     if (buy.quantity <= 0) return;
@@ -262,12 +258,11 @@ const TradeModal = ({
           </p>
         </div>
 
-        {/* The receipt totals: what this trade does to your money,
-            priced live from the stepper */}
-        <div className="text-xs uppercase tracking-wider space-y-1.5 border-t border-white/10 pt-3">
-          {side === 'buy' ? (
-            <>
-              {row(
+        {/* The receipt total: what this trade moves, priced live from
+            the stepper — one line, the player does their own math */}
+        <div className="text-xs uppercase tracking-wider border-t border-white/10 pt-3">
+          {side === 'buy'
+            ? row(
                 'Cost',
                 cost > 0 ? (
                   `−$${numberWithCommas(cost)}`
@@ -275,18 +270,8 @@ const TradeModal = ({
                   <span className="text-white/40">—</span>
                 ),
                 'tradeCost',
-              )}
-              {row(
-                'Cash after',
-                <span className="text-crt-green">
-                  ${numberWithCommas(state.cash - cost)}
-                </span>,
-                'tradeCashAfter',
-              )}
-            </>
-          ) : (
-            <>
-              {row(
+              )
+            : row(
                 'Proceeds',
                 proceeds > 0 ? (
                   <span className="text-crt-green">
@@ -297,25 +282,6 @@ const TradeModal = ({
                 ),
                 'tradeProceeds',
               )}
-              {row(
-                'Gain',
-                proceeds > 0 && asset.averageCost > 0 ? (
-                  <span
-                    className={cn(
-                      gain > 0 && 'text-crt-green',
-                      gain < 0 && 'text-crt-red',
-                    )}
-                  >
-                    {gain >= 0 ? '+' : '−'}$
-                    {numberWithCommas(Math.abs(gain))}
-                  </span>
-                ) : (
-                  <span className="text-white/40">—</span>
-                ),
-                'tradeGain',
-              )}
-            </>
-          )}
         </div>
 
         {side === 'buy' ? (

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -176,17 +176,21 @@ const TradeModal = ({
               <div data-cy="tradeModalPosition">
                 Holding{' '}
                 <span className="text-crt-cyan">×{asset.wallet}</span>{' '}
-                at avg ${numberWithCommas(asset.averageCost)}{' '}
-                <span
-                  className={cn(
-                    positionPct >= 0
-                      ? 'text-crt-green'
-                      : 'text-crt-red',
-                  )}
-                >
-                  {positionPct >= 0 ? '+' : ''}
-                  {positionPct.toFixed(1)}%
-                </span>
+                at avg ${numberWithCommas(asset.averageCost)}
+                {/* E2: suppress the green "+0.0%" right after a buy */}
+                {Math.abs(positionPct) >= 0.05 && (
+                  <span
+                    className={cn(
+                      'ml-1',
+                      positionPct > 0
+                        ? 'text-crt-green'
+                        : 'text-crt-red',
+                    )}
+                  >
+                    {positionPct > 0 ? '+' : ''}
+                    {positionPct.toFixed(1)}%
+                  </span>
+                )}
               </div>
             )}
           </div>

--- a/components/TradeStepper.tsx
+++ b/components/TradeStepper.tsx
@@ -4,8 +4,8 @@ import { normalizeQuantity } from '../helpers/utils';
 /**
  * Quantity state for a stepper, owned by the caller so the execute
  * button can live apart from the cluster (owner design, 2026-07-16:
- * set both buy and sell amounts, then commit with big buttons at the
- * bottom of the trade panel).
+ * set the amount, then commit with a big button at the bottom of the
+ * trade panel).
  */
 export const useTradeQuantity = (max: number) => {
   const [raw, setRaw] = useState(() => String(Math.min(1, max)));
@@ -33,20 +33,15 @@ export const useTradeQuantity = (max: number) => {
 export type TradeQuantity = ReturnType<typeof useTradeQuantity>;
 
 /**
- * The quantity cluster: (✕) (−) [n] (+) (Max).
- *
- * Owner-specified design (2026-07-17, iterated 2026-07-16 playtest):
- * explicit, editable quantity with big tap targets, clamped to
- * [0, max]. This retires the old "empty input = max" convention — a
- * default you couldn't discover by looking — and replaces the native
- * number-input spinners with themed buttons. The execute button is the
- * caller's: pass the same `control` to both.
+ * The quantity cluster, grouped as (Max)  (−)(+)  [n] per the owner's
+ * 2026-07-17 playtest notes: fill shortcut first, fine-tuning pair
+ * together, the number last — right next to the receipt amounts it
+ * drives. Editable, clamped to [0, max] on blur; no native spinners.
  */
 const TradeStepper = ({
   assetName,
   maxLabel,
   disabled,
-  disabledReason,
   cyPrefix,
   control,
 }: {
@@ -54,8 +49,6 @@ const TradeStepper = ({
   /** Label for the fill-to-max button: "Max" for buys, "All" for sells */
   maxLabel: string;
   disabled: boolean;
-  /** Shown inline when the row is disabled — hover titles don't exist on touch */
-  disabledReason?: string;
   /** data-cy prefix for the input and step buttons, e.g. "solana" or "solanaSell" */
   cyPrefix: string;
   control: TradeQuantity;
@@ -75,7 +68,7 @@ const TradeStepper = ({
       type="button"
       onClick={onClick}
       disabled={disabled || stepDisabled}
-      className="btn px-2 py-1 text-xs bg-black text-crt-cyan border-crt-cyan/50 disabled:opacity-40 disabled:cursor-not-allowed"
+      className="btn px-2.5 py-1 text-xs bg-black text-crt-cyan border-crt-cyan/50 disabled:opacity-40 disabled:cursor-not-allowed"
       data-cy={cy}
       aria-label={ariaLabel}
     >
@@ -84,15 +77,15 @@ const TradeStepper = ({
   );
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-1.5 justify-end flex-wrap">
-        {stepButton(
-          '✕',
-          () => setQuantity(0),
-          quantity === 0,
-          `${cyPrefix}Zero`,
-          `Clear ${assetName} amount`,
-        )}
+    <div className="flex items-center justify-end gap-4">
+      {stepButton(
+        maxLabel,
+        () => setQuantity(max),
+        quantity >= max,
+        `${cyPrefix}MaxButton`,
+        `Set ${assetName} amount to ${maxLabel.toLowerCase()}`,
+      )}
+      <div className="flex items-center gap-1.5">
         {stepButton(
           '−',
           () => setQuantity(quantity - 1),
@@ -100,19 +93,6 @@ const TradeStepper = ({
           `${cyPrefix}Minus`,
           `Decrease ${assetName} amount`,
         )}
-        <input
-          type="number"
-          min={0}
-          max={max}
-          value={raw}
-          onChange={(e) => setRaw(e.target.value)}
-          onBlur={() => setRaw(String(quantity))}
-          disabled={disabled}
-          inputMode="numeric"
-          className="w-14 bg-black/40 border border-white/20 rounded px-1.5 py-1 text-sm text-center text-white/90 disabled:opacity-40"
-          data-cy={`${cyPrefix}AmountInput`}
-          aria-label={`Amount of ${assetName}`}
-        />
         {stepButton(
           '+',
           () => setQuantity(quantity + 1),
@@ -120,19 +100,20 @@ const TradeStepper = ({
           `${cyPrefix}Plus`,
           `Increase ${assetName} amount`,
         )}
-        {stepButton(
-          maxLabel,
-          () => setQuantity(max),
-          quantity >= max,
-          `${cyPrefix}MaxButton`,
-          `Set ${assetName} amount to ${maxLabel.toLowerCase()}`,
-        )}
       </div>
-      {disabled && disabledReason && (
-        <p className="text-xs text-white/50 text-right">
-          {disabledReason}
-        </p>
-      )}
+      <input
+        type="number"
+        min={0}
+        max={max}
+        value={raw}
+        onChange={(e) => setRaw(e.target.value)}
+        onBlur={() => setRaw(String(quantity))}
+        disabled={disabled}
+        inputMode="numeric"
+        className="w-14 bg-black/40 border border-white/20 rounded px-1.5 py-1 text-sm text-center text-white/90 disabled:opacity-40"
+        data-cy={`${cyPrefix}AmountInput`}
+        aria-label={`Amount of ${assetName}`}
+      />
     </div>
   );
 };

--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -102,6 +102,7 @@ describe("Accessibility (axe)", () => {
   it("how-to-play modal has no violations", () => {
     cy.visit("http://localhost:3000/game?seed=42")
     cy.get("#startGame").click()
+    cy.get("#openSettings").click()
     cy.get("#openHowToPlay").click()
     cy.get("[data-cy='howToPlayScreen']").should("be.visible")
     cy.injectAxe()

--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -81,6 +81,15 @@ describe("Accessibility (axe)", () => {
     cy.checkA11y(undefined, undefined, logViolations)
   })
 
+  it("desktop layout with panel dividers has no violations", () => {
+    cy.viewport(1280, 900)
+    cy.visit("http://localhost:3000/game?seed=42")
+    cy.get("#startGame").click()
+    cy.get("[data-cy='logDivider']").should("be.visible")
+    cy.injectAxe()
+    cy.checkA11y(undefined, undefined, logViolations)
+  })
+
   it("settings modal has no violations", () => {
     cy.visit("http://localhost:3000/game?seed=42")
     cy.get("#startGame").click()

--- a/cypress/e2e/features.cy.ts
+++ b/cypress/e2e/features.cy.ts
@@ -58,10 +58,13 @@ describe("Testing main features and function", () => {
     cy.get("[data-cy='solanaRow']").click()
     // stepper defaults to 1; typed values replace it
     cy.get("[data-cy='solanaAmountInput']").clear().type("2")
+    // the receipt prices the trade live: 2 × $55 (seed 42, day 2)
+    cy.get("[data-cy='tradeCost']").should("contain", "$110")
     cy.get("[data-cy='solanaBuyButton']").click()
     cy.get("[data-cy='solanaAssetWallet']").should("have.text", "2")
     // holdings row reopens straight onto Sell; stepper defaults to 1
     cy.get("[data-cy='solanaHoldingRow']").click()
+    cy.get("[data-cy='tradeProceeds']").should("contain", "$55")
     cy.get("[data-cy='solanaSellButton']").click()
     cy.get("[data-cy='solanaAssetWallet']").should("have.text", "1")
   })
@@ -100,8 +103,11 @@ describe("Testing main features and function", () => {
         expect(clamped).to.be.greaterThan(0)
         expect(clamped).to.be.lessThan(99999)
       })
-    // zero disables the buy action
-    cy.get("[data-cy='solanaZero']").click()
+    // a typed zero disables the buy action
+    cy.get("[data-cy='solanaAmountInput']")
+      .clear()
+      .type("0")
+      .trigger("focusout")
     cy.get("[data-cy='solanaBuyButton']").should("be.disabled")
     // plus re-enables
     cy.get("[data-cy='solanaPlus']").click()
@@ -148,6 +154,8 @@ describe("Testing main features and function", () => {
 
   it("resets and starts a new game (with tap-again confirm)", () => {
     cy.get("#advDay").click()
+    // abandoning lives in the settings menu now (meta, not gameplay)
+    cy.get("#openSettings").click()
     // first tap arms the confirm, second tap resets
     cy.get("#runInfo").click()
     cy.get("#runInfo").should("contain", "TAP AGAIN")
@@ -159,6 +167,7 @@ describe("Testing main features and function", () => {
   })
 
   it("starts an easy mode run with its own settings", () => {
+    cy.get("#openSettings").click()
     cy.get("#runInfo").click()
     cy.get("#runInfo").click()
     cy.get("#easyMode").click()

--- a/cypress/e2e/features.cy.ts
+++ b/cypress/e2e/features.cy.ts
@@ -152,6 +152,28 @@ describe("Testing main features and function", () => {
     cy.get("[data-cy='assetPrice']").eq(3).should("have.text", "$86")
   })
 
+  it("folds finished days in the activity log", () => {
+    cy.get("#advDay").click()
+    cy.get("#advDay").click()
+    // day 1's entries live under their collapsed day header. Assert
+    // the fold via the open attribute: Chrome hides closed-details
+    // content with content-visibility, which keeps layout boxes and
+    // fools Cypress's visibility check into seeing it.
+    cy.contains("summary", "end of day 1")
+      .parent("details")
+      .should("not.have.attr", "open")
+    cy.contains("summary", "end of day 1").click()
+    cy.contains("summary", "end of day 1")
+      .parent("details")
+      .should("have.attr", "open")
+    cy.contains("You borrowed").should("be.visible")
+    // and fold back up
+    cy.contains("summary", "end of day 1").click()
+    cy.contains("summary", "end of day 1")
+      .parent("details")
+      .should("not.have.attr", "open")
+  })
+
   it("resets and starts a new game (with tap-again confirm)", () => {
     cy.get("#advDay").click()
     // abandoning lives in the settings menu now (meta, not gameplay)

--- a/cypress/e2e/responsive.cy.ts
+++ b/cypress/e2e/responsive.cy.ts
@@ -51,6 +51,45 @@ describe("Responsive layout", () => {
     // holding a coin adds the holding marker + avg price to the row
     noTableOverflow("holding a coin")
     noHorizontalOverflow("modal closed")
+    // B3: market first on phones — the table sits above the net-worth
+    // stat, and the duplicate holdings panel doesn't render at all
+    cy.get("[data-cy='marketTable']").then(($table) => {
+      cy.get("[data-cy='netWorth']").then(($net) => {
+        expect(
+          $table[0].getBoundingClientRect().top,
+          "market table above portfolio stats",
+        ).to.be.lessThan($net[0].getBoundingClientRect().top)
+      })
+    })
+    cy.get("[data-cy='solanaHoldingRow']").should("not.be.visible")
+  })
+
+  it("desktop (1280px): drag dividers resize and persist via settings", () => {
+    cy.viewport(1280, 900)
+    freshVisit()
+    cy.get("#startGame").click({ force: true })
+    // keyboard resize: two ArrowDown presses = +32px on the log
+    cy.get("[data-cy='logDivider']")
+      .should("be.visible")
+      .focus()
+      .type("{downArrow}{downArrow}")
+      .should("have.attr", "aria-valuenow", "352")
+    cy.get("[data-cy='sidebarDivider']")
+      .focus()
+      .type("{rightArrow}")
+      .should("have.attr", "aria-valuenow", "336")
+    // sizes are device preferences: they survive a reload via settings
+    cy.reload()
+    cy.get("[data-cy='logDivider']").should(
+      "have.attr",
+      "aria-valuenow",
+      "352",
+    )
+    cy.get("[data-cy='sidebarDivider']").should(
+      "have.attr",
+      "aria-valuenow",
+      "336",
+    )
   })
 
   it("desktop (1280px): sidebar and trade area sit side by side, no overflow", () => {

--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -54,8 +54,12 @@ describe("Settings & How to play", () => {
     })
   })
 
-  it("opens and closes how to play", () => {
+  it("opens how to play from the settings menu", () => {
+    // How to play lives inside settings now (meta, not gameplay)
+    cy.get("#openSettings").click()
     cy.get("#openHowToPlay").click()
+    // opening help closes the settings menu behind it
+    cy.get("[data-cy='settingsScreen']").should("not.exist")
     cy.get("[data-cy='howToPlayScreen']").should("be.visible")
     cy.contains("cash minus debt").should("be.visible")
     cy.get("#howToPlayClose").click()

--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -15,6 +15,12 @@ describe("Settings & How to play", () => {
       .click()
       .should("have.attr", "aria-checked", "false")
 
+    // music defaults off — it's a taste thing
+    cy.get("#musicToggle")
+      .should("have.attr", "aria-checked", "false")
+      .click()
+      .should("have.attr", "aria-checked", "true")
+
     cy.get("#crtToggle").click()
     // the CRT toggle stamps a data attribute on <html>
     cy.document()
@@ -27,6 +33,7 @@ describe("Settings & How to play", () => {
     cy.reload()
     cy.get("#openSettings").click()
     cy.get("#soundToggle").should("have.attr", "aria-checked", "false")
+    cy.get("#musicToggle").should("have.attr", "aria-checked", "true")
     cy.get("#crtToggle").should("have.attr", "aria-checked", "false")
     cy.document()
       .its("documentElement.dataset.crt")

--- a/lib/SettingsContext.tsx
+++ b/lib/SettingsContext.tsx
@@ -10,6 +10,7 @@ import {
   saveSettings,
 } from './state/settings';
 import { setSoundEnabled } from './sound';
+import { setMusicEnabled } from './music';
 
 interface SettingsContextType {
   settings: Settings;
@@ -43,6 +44,7 @@ export const SettingsProvider = ({
   useEffect(() => {
     saveSettings(settings);
     setSoundEnabled(settings.sound);
+    setMusicEnabled(settings.music);
     document.documentElement.dataset.crt = settings.crt ? 'on' : 'off';
   }, [settings]);
 

--- a/lib/music.ts
+++ b/lib/music.ts
@@ -1,0 +1,137 @@
+/**
+ * Background music: a sparse, generative chiptune loop synthesized with
+ * the Web Audio API — same no-assets approach as lib/sound.ts, and the
+ * same side-effect-layer contract: the SettingsProvider flips it on and
+ * off, everything no-ops when audio is unavailable.
+ *
+ * Browsers block audio until a user gesture. Toggling the setting IS a
+ * gesture, so that path just works; when music is already enabled on
+ * page load, a one-time pointer/key listener starts it on the first
+ * interaction instead.
+ */
+
+let enabled = false;
+let ctx: AudioContext | null = null;
+let master: GainNode | null = null;
+let schedulerId: ReturnType<typeof setInterval> | null = null;
+let nextStepTime = 0;
+let step = 0;
+
+const TEMPO = 92; // bpm
+const STEP = 60 / TEMPO / 2; // eighth notes
+const LOOKAHEAD_MS = 120;
+const SCHEDULE_AHEAD = 0.4; // seconds
+
+// A minor pentatonic, low register — moody terminal hum, not a jingle
+const BASS = [110, 110, 0, 110, 0, 130.81, 110, 0]; // A2 riff w/ C3
+const LEAD = [
+  0, 220, 261.63, 0, 329.63, 0, 293.66, 220, 0, 0, 261.63, 0, 220, 0,
+  0, 0,
+]; // A3/C4/E4/D4 phrase over two bars
+
+const getContext = (): AudioContext | null => {
+  if (typeof window === 'undefined') return null;
+  const AC =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!AC) return null;
+  if (!ctx) {
+    ctx = new AC();
+    master = ctx.createGain();
+    master.gain.value = 0.018;
+    master.connect(ctx.destination);
+  }
+  return ctx;
+};
+
+const voice = (
+  audio: AudioContext,
+  freq: number,
+  time: number,
+  duration: number,
+  type: OscillatorType,
+  volume: number,
+) => {
+  if (!master || freq <= 0) return;
+  const osc = audio.createOscillator();
+  const gain = audio.createGain();
+  osc.type = type;
+  osc.frequency.value = freq;
+  gain.gain.setValueAtTime(volume, time);
+  gain.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+  osc.connect(gain);
+  gain.connect(master);
+  osc.start(time);
+  osc.stop(time + duration);
+};
+
+const scheduleSteps = (audio: AudioContext) => {
+  while (nextStepTime < audio.currentTime + SCHEDULE_AHEAD) {
+    voice(
+      audio,
+      BASS[step % BASS.length],
+      nextStepTime,
+      STEP * 0.9,
+      'triangle',
+      1,
+    );
+    voice(
+      audio,
+      LEAD[step % LEAD.length],
+      nextStepTime,
+      STEP * 1.6,
+      'square',
+      0.35,
+    );
+    nextStepTime += STEP;
+    step += 1;
+  }
+};
+
+const start = () => {
+  const audio = getContext();
+  if (!audio || schedulerId !== null) return;
+  const begin = () => {
+    if (schedulerId !== null || !enabled) return;
+    nextStepTime = audio.currentTime + 0.05;
+    step = 0;
+    schedulerId = setInterval(
+      () => scheduleSteps(audio),
+      LOOKAHEAD_MS,
+    );
+  };
+  if (audio.state === 'suspended') {
+    // No gesture yet (music was enabled on a previous visit): arm a
+    // one-time listener and start on the first interaction.
+    void audio.resume().then(() => {
+      if (audio.state === 'running') begin();
+    });
+    const onGesture = () => {
+      window.removeEventListener('pointerdown', onGesture);
+      window.removeEventListener('keydown', onGesture);
+      void audio.resume().then(begin);
+    };
+    window.addEventListener('pointerdown', onGesture);
+    window.addEventListener('keydown', onGesture);
+  } else {
+    begin();
+  }
+};
+
+const stop = () => {
+  if (schedulerId !== null) {
+    clearInterval(schedulerId);
+    schedulerId = null;
+  }
+};
+
+export const setMusicEnabled = (on: boolean): void => {
+  enabled = on;
+  try {
+    if (on) start();
+    else stop();
+  } catch {
+    // music is best-effort, never break the game over it
+  }
+};

--- a/lib/priceEvents.ts
+++ b/lib/priceEvents.ts
@@ -44,7 +44,7 @@ export const priceMovementEvent = (
     `The World Series of Poker's main prize is now 1 million ${asset}! All in!`,
     `A glitch in ${asset}'s code deleted half of the supply! Prices soar!`,
     `Marty McFly has traveled back in time and bought $1 million of ${asset}! Don't miss out!`,
-    `A reddit thread on r/wallstreetbets about ${asset} has gone viral! Sell high!`,
+    `A post on r/wallstreetbets about ${asset} has gone viral! Sell high!`,
     `Apes figured out how to use ${asset} to buy bananas! Prices are apeeling!`,
     `The NBA has announced that they will be paying players in ${asset}! Scores and prices are up!`,
     `For no particular technical or news event, ${asset} has gone parabolic!`,

--- a/lib/state/settings.test.ts
+++ b/lib/state/settings.test.ts
@@ -24,11 +24,19 @@ describe('settings', () => {
   });
 
   it('round-trips', () => {
-    saveSettings({ sound: false, crt: false });
-    expect(loadSettings()).toEqual({ sound: false, crt: false });
+    const custom = {
+      sound: false,
+      music: true,
+      crt: false,
+      sidebarWidth: 360,
+      logHeight: 240,
+    };
+    saveSettings(custom);
+    expect(loadSettings()).toEqual(custom);
   });
 
   it('merges stored values over defaults (forward compat)', () => {
+    // e.g. a pre-music/pre-layout save from an earlier version
     store.set('cryptoFrenzySettings', JSON.stringify({ sound: false }));
     expect(loadSettings()).toEqual({ ...defaultSettings, sound: false });
   });

--- a/lib/state/settings.ts
+++ b/lib/state/settings.ts
@@ -7,15 +7,24 @@
 export type Settings = {
   /** Sound effects on/off */
   sound: boolean;
+  /** Background music on/off — defaults off; it's a taste thing */
+  music: boolean;
   /** CRT visual effects (scanlines, glow) on/off */
   crt: boolean;
+  /** Desktop sidebar width in px; null = the CSS default */
+  sidebarWidth: number | null;
+  /** Desktop activity-log height in px; null = the CSS default */
+  logHeight: number | null;
 };
 
 const SETTINGS_KEY = 'cryptoFrenzySettings';
 
 export const defaultSettings: Settings = {
   sound: true,
+  music: false,
   crt: true,
+  sidebarWidth: null,
+  logHeight: null,
 };
 
 export const loadSettings = (): Settings => {

--- a/pages/Game.tsx
+++ b/pages/Game.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useReducer, useState } from 'react';
+import {
+  CSSProperties,
+  useEffect,
+  useReducer,
+  useState,
+} from 'react';
 import { reducer } from '../lib/reducer';
 import { initialState } from '../lib/state/initialState';
 import {
@@ -20,6 +25,8 @@ import GameOver from '../components/GameOver';
 import Settings from '../components/Settings';
 import HowToPlay from '../components/HowToPlay';
 import TradeModal, { TradeSide } from '../components/TradeModal';
+import Divider from '../components/Divider';
+import { useSettings } from '../lib/SettingsContext';
 
 export default function Game() {
   usePageTitle('Crypto Frenzy – Game');
@@ -87,6 +94,10 @@ export default function Game() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.currentDay]);
 
+  // Desktop panel sizes (E4): device preferences, so they live in
+  // settings, not in the seeded, replayable game state.
+  const { settings, update } = useSettings();
+
   // Warn when one in-game day remains.
   const { showNotification } = useNotification();
   useEffect(() => {
@@ -115,7 +126,20 @@ export default function Game() {
         <StatusBar dispatch={dispatch} state={state} />
 
         <div className="flex-1 flex flex-col lg:flex-row min-w-0">
-          <div className="w-full lg:w-1/4 lg:shrink-0 min-w-0 border-b lg:border-b-0 lg:border-r border-white/10 bg-crt-panel/50 px-4 py-6">
+          {/* B3: on phones the market comes first and the portfolio
+              second (order-2) — previously a full screen of stats stood
+              between the player and the game. Desktop keeps the
+              sidebar on the left, at a width the player can drag. */}
+          <div
+            className="w-full lg:w-[var(--sidebar-w,25%)] lg:shrink-0 min-w-0 order-2 lg:order-none border-t lg:border-t-0 border-white/10 bg-crt-panel/50 px-4 py-6"
+            style={
+              settings.sidebarWidth != null
+                ? ({
+                    '--sidebar-w': `${settings.sidebarWidth}px`,
+                  } as CSSProperties)
+                : undefined
+            }
+          >
             <GameSidebar
               state={state}
               dispatch={dispatch}
@@ -127,20 +151,56 @@ export default function Game() {
             />
           </div>
 
+          <div className="hidden lg:block lg:order-none">
+            <Divider
+              orientation="vertical"
+              label="Resize sidebar"
+              dataCy="sidebarDivider"
+              value={settings.sidebarWidth ?? 320}
+              min={240}
+              max={480}
+              onChange={(sidebarWidth) => update({ sidebarWidth })}
+            />
+          </div>
+
           {/* No mx-auto: auto margins disable flex-item stretch, which at
               mobile widths sized this column to its content's intrinsic
               width (the unwrapped log/table, ~600px) instead of the
               viewport — the root cause of horizontal overflow on phones.
               flex-1 already fills the row on desktop. */}
-          <div className="flex flex-1 flex-col min-w-0 px-4 py-6 gap-6">
-            <div className="w-full space-y-6">
-              <Log log={state.log} />
+          <div
+            className="flex flex-1 flex-col min-w-0 order-1 lg:order-none px-4 py-6 gap-6"
+            style={
+              settings.logHeight != null
+                ? ({
+                    '--log-h': `${settings.logHeight}px`,
+                  } as CSSProperties)
+                : undefined
+            }
+          >
+            {/* Market first on phones (order-1); desktop reads log
+                over market with a draggable boundary between them */}
+            <div className="w-full order-1 lg:order-3">
               <AssetTable
                 state={state}
                 onSelectAsset={(assetKey) =>
                   setTrade({ assetKey, side: 'buy' })
                 }
               />
+            </div>
+            <div className="hidden lg:block lg:order-2">
+              <Divider
+                orientation="horizontal"
+                label="Resize activity log"
+                dataCy="logDivider"
+                value={settings.logHeight ?? 320}
+                min={120}
+                max={640}
+                onChange={(logHeight) => update({ logHeight })}
+              />
+            </div>
+            <div className="w-full order-2 lg:order-1 space-y-3">
+              <Log log={state.log} />
             </div>
           </div>
         </div>

--- a/pages/Game.tsx
+++ b/pages/Game.tsx
@@ -11,7 +11,10 @@ import {
   saveGame,
   clearSave,
 } from '../lib/state/persistence';
-import { saveHighScore } from '../lib/state/highScores';
+import {
+  loadHighScore,
+  saveHighScore,
+} from '../lib/state/highScores';
 import { useNotification } from '../lib/NotificationContext';
 import { playSound } from '../lib/sound';
 import { AlertMessages } from '../helpers/alerts';
@@ -98,6 +101,17 @@ export default function Game() {
   // settings, not in the seeded, replayable game state.
   const { settings, update } = useSettings();
 
+  // Abandon lives in the settings menu now (meta, not gameplay) —
+  // the confirm handshake happens there; this is the commit.
+  const abandonRun = () => {
+    clearSave();
+    dispatch({
+      type: 'INIT',
+      payload: { highScore: loadHighScore(state.mode) },
+    });
+    setSettingsOpen(false);
+  };
+
   // Warn when one in-game day remains.
   const { showNotification } = useNotification();
   useEffect(() => {
@@ -131,7 +145,7 @@ export default function Game() {
               between the player and the game. Desktop keeps the
               sidebar on the left, at a width the player can drag. */}
           <div
-            className="w-full lg:w-[var(--sidebar-w,25%)] lg:shrink-0 min-w-0 order-2 lg:order-none border-t lg:border-t-0 border-white/10 bg-crt-panel/50 px-4 py-6"
+            className="w-full lg:w-[var(--sidebar-w,25%)] lg:shrink-0 min-w-0 order-2 lg:order-none border-t lg:border-t-0 border-white/10 bg-crt-panel/50 px-4 py-6 flex flex-col"
             style={
               settings.sidebarWidth != null
                 ? ({
@@ -144,7 +158,6 @@ export default function Game() {
               state={state}
               dispatch={dispatch}
               onOpenSettings={() => setSettingsOpen(true)}
-              onOpenHelp={() => setHelpOpen(true)}
               onSelectAsset={(assetKey) =>
                 setTrade({ assetKey, side: 'sell' })
               }
@@ -213,7 +226,11 @@ export default function Game() {
         <GameOver state={state} dispatch={dispatch} />
       )}
       {settingsOpen && (
-        <Settings onClose={() => setSettingsOpen(false)} />
+        <Settings
+          onClose={() => setSettingsOpen(false)}
+          onOpenHelp={() => setHelpOpen(true)}
+          onAbandonRun={abandonRun}
+        />
       )}
       {helpOpen && <HowToPlay onClose={() => setHelpOpen(false)} />}
       {trade && !state.gameOver && !state.modalOpen && (

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -77,18 +77,10 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="grid md:grid-cols-3 gap-4 text-xs md:text-sm text-slate-300 border-t border-crt-outline pt-6 mt-2">
-            <div className="space-y-2">
-              <h3 className="text-crt-cyan font-semibold">
-                MAIN MENU
-              </h3>
-              <ul className="space-y-1">
-                <li>▶ START RUN</li>
-                <li className="text-slate-500">▢ PROFILES (SOON)</li>
-                <li className="text-slate-500">▢ SETTINGS (SOON)</li>
-                <li className="text-slate-500">▢ CREDITS (SOON)</li>
-              </ul>
-            </div>
+          {/* Menu stubs (PROFILES/CREDITS "SOON") cut per roadmap —
+              vaporware menu items undercut the "real game" feel;
+              Credits returns as a real page in Phase 2 */}
+          <section className="grid md:grid-cols-2 gap-4 text-xs md:text-sm text-slate-300 border-t border-crt-outline pt-6 mt-2">
             <div className="space-y-2">
               <h3 className="text-crt-cyan font-semibold">
                 DIFFICULTY (IN-GAME)


### PR DESCRIPTION
## Phase 1f — PR 3 (final): the remaining seven inventory items

This closes out the comprehensive UX sweep. With this merged, **Phase 1f is done** and Phase 2 (web release) is next.

### Information hierarchy
- **B2 — NET WORTH is a stat row now**, not the largest element in the game. Green when you're up; calm neutral when you're down — the giant red panel read as an alarm when negative net worth is just the starting debt. Sidebar section headings tightened to match.
- **B3 — market first on phones.** The mobile stack was a full screen of portfolio stats before you saw a price. Now: status bar → market table → activity → portfolio. The sidebar **holdings panel doesn't render below `md`** — the table already shows the dot/avg/qty and its rows open the trade modal on Sell, so it was pure duplication (resolves the open decision from PR #40).

### Market feedback
- **C3 — activity log hierarchy** (presentation only; the save format is untouched): market events read bright, moonshots green, crashes red-edged, your own trades quiet, and `==== End of Day ====` walls became thin centered day markers — with empty-day duplicates collapsed to one.
- **E2 — no more green "+0.0%"** right after every buy: near-zero position deltas render nothing (holdings rows + trade modal).

### Desktop density (owner request)
- **E3 — the log fills real space**: 40vh by default instead of ~3 lines above dead space.
- **E4 — drag-resizeable panels**: dividers between sidebar/content and log/market. Pointer drag or arrow keys (`role="separator"` with value semantics, axe-scanned). Sizes persist in **settings**, not game state — layout is a device preference.

### Odds & ends
- **Landing stubs cut** (PROFILES/SETTINGS/CREDITS "SOON") — vaporware menu items undercut the real-game feel; Credits returns as a real page in Phase 2.
- **Background music**: a sparse generative chiptune loop, synthesized with Web Audio like the SFX (zero assets). **Off by default** — it's a taste thing — with a Settings toggle; honors autoplay policy by starting on first interaction when pre-enabled. Taste verdict welcome: toggle it in Settings.

### Tests
56 unit / 29 E2E green. New coverage: divider keyboard-resize + persistence across reload, mobile market-before-portfolio and hidden-holdings assertions, a desktop-layout axe scan (dividers), music toggle persistence, and settings round-trip with the new fields.

### ROADMAP
All seven items ticked with outcomes, Phase 1f marked ✅, the holdings-on-mobile open decision resolved, sequencing updated to point at Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)