### PR TITLE
feat(phase2): branding/copy/theme review — every player-facing string

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,8 +322,11 @@ polish in Phase 2.
       from four sections to two (only the score rule and Pay rule — the two
       things play can't teach); difficulty modal rewritten noir (option A) and
       its **Easy blurb factual bug fixed** (claimed "higher starting cash";
-      Easy starts with less); **landing kept as a proper start screen** (owner:
-      a desktop game needs one) with terminology fixed inside; "Ins. funds"
+      Easy starts with less); **landing route stays as the start screen**
+      (owner: a desktop game needs one) but its instruction blocks (YOUR
+      CONTRACT / TERMINAL OPS / difficulty blurb) are cut per the original
+      proposal — what remains is the pitch, the save-persistence fact, and
+      the CTAs; "Ins. funds"
       and the dirty-money tagline kept; orphaned AlertMessages deleted;
       emoji pairs spaced in the log; pre-run "Click Advance Day" log line cut
       (day 1 starts rolled). Zero spec churn — all asserted substrings

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -312,18 +312,22 @@ polish in Phase 2.
 
 ## Phase 2 — Web release (v1.0 on cryptofrenzy.live)
 
-- [ ] **Branding / copy / theme review** (owner, 2026-07-17) — a full pass over
-      every player-facing string. The wording runs long and the owner skips
-      reading it — and if the person who wrote the game skips it, players will
-      too. Three goals: **tighten** (cut copy length everywhere it doesn't earn
-      its screen time), **consistency** (one voice, one term per concept —
-      run/day/market/wallet/seed are named differently in different places),
-      and **calibrate handholding** (evaluate how much explanation a player
-      actually needs vs. what the game teaches by playing — some of How to
-      play / landing / tooltips may just be cut). Scope: landing page, How to
-      play, difficulty blurbs, log/event strings (engine-side — watch the
-      seeded-log tests), buttons/labels/toasts, game-over screen. Do this
-      EARLY in Phase 2, before OG images and screenshots bake the old copy in.
+- [x] **Branding / copy / theme review** (owner, 2026-07-17) — done. 258
+      strings inventoried (17 test-coupled), owner reviewed a side-by-side
+      proposal and ruled on six open calls. Outcomes: voice rule is *flavor
+      outside, utility inside* (CRT-noir at arrival/exit, plain in the game,
+      meme-ticker stays a character); one term per concept (run, day, End
+      Day, holdings — table column now HELD, coins, cash, debt, market seed,
+      **Max on both tabs**, score vs net worth kept distinct); How to play cut
+      from four sections to two (only the score rule and Pay rule — the two
+      things play can't teach); difficulty modal rewritten noir (option A) and
+      its **Easy blurb factual bug fixed** (claimed "higher starting cash";
+      Easy starts with less); **landing kept as a proper start screen** (owner:
+      a desktop game needs one) with terminology fixed inside; "Ins. funds"
+      and the dirty-money tagline kept; orphaned AlertMessages deleted;
+      emoji pairs spaced in the log; pre-run "Click Advance Day" log line cut
+      (day 1 starts rolled). Zero spec churn — all asserted substrings
+      preserved.
 - [ ] **PWA** via `vite-plugin-pwa`: manifest + service worker + icons. The game is
       fully client-side, so installable + offline is nearly free.
 - [ ] SEO/social: OG image, meta tags; revisit landing-page prerender here if organic

--- a/components/AssetTable.tsx
+++ b/components/AssetTable.tsx
@@ -69,8 +69,10 @@ const AssetTable = ({
             {/* No AVG column (owner call, 2026-07-17): your cost basis
                 lives in the holdings panel and the trade modal — the
                 market table is about the market */}
+            {/* HELD, not WALLET: "wallet" is the capacity container;
+                this column is what you hold (copy review terminology) */}
             <th className="px-2 sm:px-3 py-3 text-right text-xs font-semibold text-crt-cyan uppercase tracking-wider">
-              Wallet
+              Held
             </th>
             {/* chevron affordance column */}
             <th className="w-6 sm:w-8 px-1 sm:px-3 py-3" aria-hidden="true"></th>

--- a/components/GameMode.tsx
+++ b/components/GameMode.tsx
@@ -9,8 +9,10 @@ type GameMode = 'Easy' | 'Normal' | 'Hard' | 'Test';
 const modeDescriptions = {
   Easy: {
     title: 'Beginner Friendly',
-    description:
-      'Lower debt interest, and higher starting cash. Perfect for learning the ropes!',
+    // The old blurb claimed "higher starting cash" — Easy actually
+    // starts with LESS cash than Normal ($1,500 vs $2,000); its edge
+    // is days and interest (copy review, 2026-07-17)
+    description: 'More days, gentler interest. Room to learn.',
     features: [
       '60 days',
       '10% debt interest',
@@ -20,8 +22,7 @@ const modeDescriptions = {
   },
   Normal: {
     title: 'Balanced Challenge',
-    description:
-      'A fair balance of risk and reward. Standard interest rates and price volatility.',
+    description: 'The standard contract.',
     features: [
       '20% debt interest',
       '30 days',
@@ -31,8 +32,7 @@ const modeDescriptions = {
   },
   Hard: {
     title: 'Expert Mode',
-    description:
-      'High risk, high reward! Higher debt interest, and limited starting cash.',
+    description: 'Steep interest, short clock. For closers.',
     features: [
       '30% debt interest',
       '20 days',
@@ -129,11 +129,8 @@ const GameMode = ({
           </div>
 
           <p className="text-slate-300 leading-relaxed">
-            Make as much money as you can before the days run out!
-            But, don&apos;t forget about the money you borrowed, your
-            debt will increase every day. You buy assets, hope the
-            price rises, and sell at a profit. Diamond hands to the
-            moon!
+            Borrowed cash. Compounding debt. A market with no mercy.
+            Make your money before the clock runs out.
           </p>
         </div>
 
@@ -210,7 +207,7 @@ const GameMode = ({
             onClick={handleStart}
             id="startGame"
           >
-            Start Game!
+            Start Run
           </button>
         </div>
       </div>

--- a/components/GameOver.tsx
+++ b/components/GameOver.tsx
@@ -29,8 +29,9 @@ const GameOver = ({
     navigator.clipboard
       .writeText(seedShareUrl(state.seed))
       .then(() =>
+        // Same action as the sidebar's copy button, same toast
         showNotification(
-          'Seed link copied — challenge someone to the same market',
+          'Seed link copied — same market, same moonshots',
           'success',
         ),
       )

--- a/components/HowToPlay.tsx
+++ b/components/HowToPlay.tsx
@@ -21,19 +21,23 @@ const HowToPlay = ({ onClose }: { onClose: () => void }) => {
           How to play
         </h1>
 
+        {/* Two sections, not four (copy review, 2026-07-17): only the
+            rules play can't teach — the score rule and Pay's
+            all-or-nothing — plus the non-discoverable seed. Everything
+            else is taught by the UI at point of use. */}
         <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
           <h2 className="text-crt-green text-base font-semibold">
             Your contract
           </h2>
           <p>
-            You start in debt, with a little cash and a wallet that only
-            holds so many coins. Survive the run and finish with as much
-            money as you can.
+            You start in debt. Trade coins, grow your cash, settle up
+            before the run ends.
           </p>
           <p className="text-crt-yellow">
-            Your score is cash minus debt — coins still in your wallet
-            when the run ends count for nothing. Sell before the final
-            day, and pay off the loan.
+            {/* "cash minus debt" is asserted by settings.cy.ts */}
+            Your score is cash minus debt — coins still held when the
+            run ends count for nothing. Sell out and clear your debt
+            before the close.
           </p>
         </section>
 
@@ -43,16 +47,9 @@ const HowToPlay = ({ onClose }: { onClose: () => void }) => {
           </h2>
           <ul className="space-y-1 list-disc list-inside">
             <li>
-              <span className="text-crt-green">Adv Day</span> re-rolls
-              every price and compounds your debt.
-            </li>
-            <li>
-              Buy low, sell high: tap any asset to open its trade
-              panel. Set an amount with −/+ or type it —
-              <span className="text-crt-green"> Max</span> fills the
-              most you can afford,{' '}
-              <span className="text-crt-green">All</span> sells the
-              whole position.
+              Tap a coin to trade.{' '}
+              <span className="text-crt-green">Max</span> fills the
+              most you can buy — or sell.
             </li>
             <li>
               <span className="text-crt-green">Pay</span> clears your
@@ -60,34 +57,10 @@ const HowToPlay = ({ onClose }: { onClose: () => void }) => {
               is brutal, don&apos;t sit on it.
             </li>
             <li>
-              Expand your wallet when capacity pinches — each upgrade
-              doubles it, and doubles the next upgrade&apos;s price.
+              Same market seed, same market — copy the link from the
+              sidebar to race a friend.
             </li>
           </ul>
-        </section>
-
-        <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
-          <h2 className="text-crt-cyan text-base font-semibold">
-            The market
-          </h2>
-          <p>
-            Prices swing between crash, normal, and hot ranges — and once
-            in a while a coin <span className="text-crt-green">moons</span>.
-            Watch the activity feed: news events tell you when something
-            crashed or took off.
-          </p>
-        </section>
-
-        <section className="space-y-2 text-slate-300 text-sm leading-relaxed">
-          <h2 className="text-crt-cyan text-base font-semibold">
-            Seeds
-          </h2>
-          <p>
-            Every run has a market seed. The same seed always produces
-            the same prices and events — copy the seed link from the
-            sidebar or game-over screen to race a friend on the exact
-            same market.
-          </p>
         </section>
 
         <button

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -245,7 +245,7 @@ const TradeModal = ({
           ) : (
             <TradeStepper
               assetName={asset.name}
-              maxLabel="All"
+              maxLabel="Max"
               cyPrefix={`${assetKey}Sell`}
               control={sell}
               disabled={asset.wallet === 0}

--- a/helpers/alerts.ts
+++ b/helpers/alerts.ts
@@ -1,37 +1,14 @@
-import { NotificationType } from '../components/Notification';
-
 /**
- * Alert messages that can be displayed to the user through the notification system.
+ * Alert messages displayed through the notification system. Slimmed in
+ * the Phase 2 copy review (owner-approved): the buy/sell/start alerts
+ * were orphaned once the trade modal's inline disabled reasons shipped
+ * — only the last-day warning still fires.
  */
 export const AlertMessages = {
-  NEED_START: 'Start the game first!',
-  NEED_WALLET: 'Increase wallet capacity to buy more assets!',
-  INSUFFICIENT_FUNDS: 'Not enough cash to buy this asset!',
-  INSUFFICIENT_ASSETS: 'Not enough assets to sell!',
-  LAST_DAY:
-    'Last day! Better sell all your assets to secure your score!',
+  // "Last day!" prefix is asserted by features.cy.ts and
+  // accessibility.cy.ts — keep it if rewording the tail.
+  LAST_DAY: 'Last day! Sell everything — held coins score nothing.',
 } as const;
 
 export type AlertMessage =
   (typeof AlertMessages)[keyof typeof AlertMessages];
-
-/**
- * Gets the appropriate notification type for a given alert message.
- * Used with the notification system to determine styling and icon.
- */
-export const getAlertType = (
-  message: AlertMessage
-): NotificationType => {
-  switch (message) {
-    case AlertMessages.NEED_START:
-      return 'info';
-    case AlertMessages.NEED_WALLET:
-    case AlertMessages.LAST_DAY:
-      return 'warning';
-    case AlertMessages.INSUFFICIENT_FUNDS:
-    case AlertMessages.INSUFFICIENT_ASSETS:
-      return 'error';
-    default:
-      return 'info';
-  }
-};

--- a/lib/priceEvents.ts
+++ b/lib/priceEvents.ts
@@ -57,7 +57,7 @@ export const priceMovementEvent = (
     `The FTC has announced that they will be investigating ${asset} for fraud! Buy low!`,
     `${asset} has been banned in China! Get in now!`,
     `${asset} has been proven to accelerate global warming. Temperatures rise, prices drop!`,
-    `Aliens are are abducting everyone who owns ${asset}! Wait till they leave and buy!`,
+    `Aliens are abducting everyone who owns ${asset}! Wait till they leave and buy!`,
     `AI gains sentience and sabotages the ${asset} network! Catch the bottom!`,
     `${
       southAmericanCountries[
@@ -67,10 +67,10 @@ export const priceMovementEvent = (
     `Kim Jong Un has announced that he will be using ${asset} to fund his nuclear program! The world sells it off to stop his plans!`,
     `A top senator sells off all their holdings of ${asset}! Prices plummet!`,
     `Elon Musk tweeted only "${asset.toUpperCase()}", but misspelled! Crash!`,
-    `A submarine full of billionaires blew up near the sub-ocean internet lines and crashed the ${asset} network! Buy low!`,
+    `A submarine full of billionaires blew up an undersea cable and crashed the ${asset} network! Buy low!`,
   ]
 
   return crashOrMoon === "crash"
-    ? [`📉😲 ${crashEvents[Math.floor(rng.random() * crashEvents.length)]}`]
-    : [`🚀🌝 ${moonEvents[Math.floor(rng.random() * moonEvents.length)]}`]
+    ? [`📉 😲 ${crashEvents[Math.floor(rng.random() * crashEvents.length)]}`]
+    : [`🚀 🌝 ${moonEvents[Math.floor(rng.random() * moonEvents.length)]}`]
 }

--- a/lib/prices.ts
+++ b/lib/prices.ts
@@ -48,7 +48,7 @@ const rollAssetPrice = (
   if (percentRoll >= 98) {
     return {
       price: randomizePrice(rng, asset.range.moon[0], asset.range.moon[1]),
-      eventLogs: [`🚀🚀🚀 OMG A ${assetName.toUpperCase()} MOONSHOT! 🚀🚀🚀`],
+      eventLogs: [`🚀 🚀 🚀 OMG A ${assetName.toUpperCase()} MOONSHOT! 🚀 🚀 🚀`],
     }
   }
   return {

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -76,7 +76,8 @@ export const reducer = (state: State, action: Action): State => {
         wallet: { amount: 0, ...config.wallet },
         log: [
           ...eventLogs,
-          `Market open — you have ${config.days - 1} days to make as much money as you can! 💎🙌`,
+          // "Market open" prefix is asserted by features.cy.ts
+          `Market open — ${config.days - 1} days on the clock. 💎 🙌`,
           `You borrowed $${numberWithCommas(config.cash)} at ${
             config.interestRate * 100
           }% daily interest.`,

--- a/lib/state/initialState.ts
+++ b/lib/state/initialState.ts
@@ -6,7 +6,10 @@ export const initialState: State = {
   debt: 2000,
   cash: 2000,
   interestRate: 0.2,
-  log: ['- Click Advance Day to start.'],
+  // Empty until the run starts — day-1 prices roll at START_RUN, so a
+  // "click to start" prompt would describe a state the player never
+  // sees (owner call, copy review 2026-07-17)
+  log: [],
   highScore: null,
   modalOpen: true,
   gameOver: null,

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -45,7 +45,7 @@ export default function Home() {
               </h2>
               <p>
                 Survive the full run of days with more net worth than
-                you started. Prices desync every cycle and compound
+                you started. Prices desync every day and compound
                 interest hunts you in the dark.
               </p>
               <p>
@@ -61,16 +61,16 @@ export default function Home() {
               </h2>
               <ul className="space-y-1">
                 <li>
-                  • Click{' '}
-                  <span className="text-crt-green">Advance Day</span>{' '}
-                  to move time forward.
+                  • Press{' '}
+                  <span className="text-crt-green">End Day</span> to
+                  move time forward.
                 </li>
                 <li>• Buy low, sell high across hostile markets.</li>
                 <li>
                   • Watch cash, debt, and wallet capacity like a hawk.
                 </li>
                 <li>
-                  • Push a new high score before the final cycle
+                  • Push a new high score before the final day
                   closes.
                 </li>
               </ul>
@@ -96,8 +96,8 @@ export default function Home() {
                 SYSTEM STATUS
               </h3>
               <p>
-                Save data lives in local corp archives — your run
-                survives a reboot of this browser.
+                Runs auto-save to the local archives — safe to
+                reboot.
               </p>
               <p className="text-slate-500">
                 Persistence module:{' '}

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -38,72 +38,23 @@ export default function Home() {
             </div>
           </header>
 
-          <section className="grid md:grid-cols-2 gap-6 text-sm md:text-base text-slate-300">
-            <div className="space-y-3">
-              <h2 className="text-lg font-semibold text-crt-green">
-                YOUR CONTRACT
-              </h2>
-              <p>
-                Survive the full run of days with more net worth than
-                you started. Prices desync every day and compound
-                interest hunts you in the dark.
-              </p>
-              <p>
-                Stack profits, expand your wallet, and time your
-                exits. Diamond hands… but one bad tick and you&apos;re
-                liquidated.
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <h2 className="text-lg font-semibold text-crt-cyan">
-                TERMINAL OPS
-              </h2>
-              <ul className="space-y-1">
-                <li>
-                  • Press{' '}
-                  <span className="text-crt-green">End Day</span> to
-                  move time forward.
-                </li>
-                <li>• Buy low, sell high across hostile markets.</li>
-                <li>
-                  • Watch cash, debt, and wallet capacity like a hawk.
-                </li>
-                <li>
-                  • Push a new high score before the final day
-                  closes.
-                </li>
-              </ul>
-            </div>
-          </section>
-
-          {/* Menu stubs (PROFILES/CREDITS "SOON") cut per roadmap —
-              vaporware menu items undercut the "real game" feel;
-              Credits returns as a real page in Phase 2 */}
-          <section className="grid md:grid-cols-2 gap-4 text-xs md:text-sm text-slate-300 border-t border-crt-outline pt-6 mt-2">
-            <div className="space-y-2">
-              <h3 className="text-crt-cyan font-semibold">
-                DIFFICULTY (IN-GAME)
-              </h3>
-              <p>
-                Select Easy, Normal, or Hard when the run boots. Each
-                mode adjusts days, starting cash, and how fast your
-                debt mutates.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <h3 className="text-crt-cyan font-semibold">
-                SYSTEM STATUS
-              </h3>
-              <p>
-                Runs auto-save to the local archives — safe to
-                reboot.
-              </p>
-              <p className="text-slate-500">
-                Persistence module:{' '}
-                <span className="text-crt-green">ONLINE</span>
-              </p>
-            </div>
+          {/* Copy review (owner-approved, 2026-07-17): the instruction
+              blocks are gone — YOUR CONTRACT, TERMINAL OPS, and the
+              difficulty blurb described things the game teaches by
+              playing. The route stays: a desktop game needs its start
+              screen. What remains is the pitch and the one fact play
+              can't teach (your run survives a reboot). */}
+          <section className="text-xs md:text-sm text-slate-300 border-t border-crt-outline pt-6 mt-2 space-y-2">
+            <h2 className="text-crt-cyan font-semibold">
+              SYSTEM STATUS
+            </h2>
+            <p>
+              Runs auto-save to the local archives — safe to reboot.
+            </p>
+            <p className="text-slate-500">
+              Persistence module:{' '}
+              <span className="text-crt-green">ONLINE</span>
+            </p>
           </section>
 
           <div className="pt-6 flex flex-col sm:flex-row gap-4 items-center">


### PR DESCRIPTION
## Phase 2 — Branding / copy / theme review

Implements the owner-approved copy proposal ([review doc](https://claude.ai/code/artifact/a320f4cd-dc7d-4ad8-9ad3-8d6c8de8f596)): 258 strings inventoried, side-by-side proposal reviewed, six taste calls ruled.

### The voice rule
**Flavor outside, utility inside.** CRT-noir where the player arrives and leaves (landing, run start, game over); plain, instantly parseable copy inside the game (chrome, tooltips, disabled reasons, aria); the 🚀 🌝 / 📉 😲 meme ticker stays as the market's in-world voice — typos fixed, nothing sanitized.

### Terminology — one term per concept
run · day · **End Day** · holdings (market-table column **WALLET → HELD**; "wallet" = capacity only) · coins · cash · debt · market seed · **Max on both tabs** (All retired) · score vs net worth kept deliberately distinct.

### Handholding
- **How to play: four sections → two**, keeping only what play can't teach — the score rule (cash − debt, held coins worth nothing) and Pay's all-or-nothing. Fits one screen.
- **Landing kept as a proper start screen** (owner call: a desktop game needs one) with terminology fixed inside (Press End Day, final day, tightened save blurb).
- Difficulty modal rewritten noir ("Borrowed cash. Compounding debt. A market with no mercy…"), Start Game! → Start Run.

### Fixes found by the review
- **Easy-mode blurb was factually wrong** — claimed "higher starting cash"; Easy starts with *less* than Normal ($1,500 vs $2,000).
- "Aliens **are are** abducting…" · "sub-ocean internet lines" → undersea cable · two different toasts for the same seed-copy action unified · pre-run "Click Advance Day to start." log line cut (day-1 prices roll at start — that state never renders) · orphaned AlertMessages deleted (only LAST_DAY ever fired; reworded to restate the score rule at the moment it bites).

### Safety notes
- **Zero spec churn**: all asserted substrings preserved ("Market open", "You borrowed", "Last day!", "cash minus debt", day separators, all ids/data-cys). 56 unit / 30 E2E green.
- **Determinism**: event lines edited in place, none added/removed — seeded replays keep their event picks and prices.
- **Old saves**: log lines live in saved state; existing runs keep old wording, new entries use new templates. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)