### PR TITLE
feat(phase2): save-file schema + forward migrations (zod)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -349,10 +349,21 @@ polish in Phase 2.
 - [ ] Analytics events beyond page views: run started/finished, mode, score.
 - [ ] Privacy page (required once you have analytics) + Credits page (IBM Plex Mono
       OFL attribution already lives in the repo).
-- [ ] Save-file schema + migrations (PR #34 review): validate saves against a real
-      schema (e.g. zod) and migrate old versions forward instead of discarding them.
-      Pre-1.0 the manual `SAVE_VERSION` bump-and-discard is intentional; this lands
-      before v1.0 ships, once real players have runs worth preserving.
+- [x] Save-file schema + migrations (PR #34 review): saves are validated with
+      zod (`lib/state/saveSchema.ts`) and older versions migrate forward
+      stepwise instead of being discarded — v1 (pre-engine) derives a pure
+      rngState and gets the seed-0 "unknown" sentinel; v2 gains previousPrice.
+      Review discovery: SAVE_VERSION 2 spans TWO shapes in the wild (`seed`
+      landed mid-version without a bump) — the migration defaults it, and the
+      schema header documents the rule: a new required State field means a
+      version bump + one migration entry; same-version additions must be
+      schema-optional with their default from the initialState spread. A
+      compile-time guard pins StateSchema to the State type so the schema
+      can't silently fall behind. Future-version saves load as null (an old
+      build never mangles a newer save). Junk `?seed=` URLs (coerce to 0) now
+      read as "no seed" so they can't false-match migrated pre-seed saves or
+      torch a resumable run. Historical fixtures are frozen literals
+      transcribed from git, not derived from the present shape.
 - [ ] Balance/playtest pass — get 5–10 people through full runs on all three modes.
 - [ ] Tag **v1.0.0**, announce.
 

--- a/lib/state/persistence.test.ts
+++ b/lib/state/persistence.test.ts
@@ -26,9 +26,71 @@ const midRun: State = {
   ...initialState,
   cash: 555,
   currentDay: 7,
+  seed: 42,
   rngState: 99,
   modalOpen: false,
 };
+
+/**
+ * FROZEN historical save shapes, transcribed from git history — NOT
+ * derived from the current State, so they can't silently drift when
+ * the present shape changes (deriving them is exactly how the
+ * early-v2 missing-seed bug hid from the first version of this
+ * suite). Two coins instead of five for readability; the shape is
+ * what matters. Sources:
+ *   v1        — commit 6b0417f (phase 1a): no seed, no rngState,
+ *               assets without previousPrice
+ *   v2 early  — commit dee581f (engine refactor): + rngState, still
+ *               NO seed (it landed later in PR #35 without a bump)
+ *   v2 late   — post-PR #35: + seed
+ */
+const frozenAsset = {
+  name: 'Bitcoin',
+  symbol: 'BTC',
+  wallet: 2,
+  active: true,
+  averageCost: 20000,
+  totalCost: 40000,
+  range: {
+    low: [3000, 9000],
+    mid: [10000, 45000],
+    high: [50000, 90000],
+    moon: [100000, 250000],
+  },
+  price: 21000,
+};
+
+const FROZEN_V1 = {
+  days: 31,
+  currentDay: 9,
+  cash: 777,
+  debt: 3100,
+  interestRate: 0.2,
+  log: ['Bought 2 Bitcoin', 'Game start'],
+  highScore: null,
+  modalOpen: false,
+  gameOver: null,
+  stats: { peakNetWorth: 500, totalTrades: 3, bestTradeProfit: 120 },
+  lowRangePriceChance: 5,
+  highRangePriceChance: 94,
+  mode: 'Normal',
+  assets: {
+    bitcoin: { ...frozenAsset },
+    solana: {
+      ...frozenAsset,
+      name: 'Solana',
+      symbol: 'SOL',
+      wallet: 0,
+      averageCost: 0,
+      totalCost: 0,
+      price: 55,
+    },
+  },
+  wallet: { amount: 2, capacity: 100, level: 0, expansionCost: 50000 },
+};
+
+const FROZEN_V2_EARLY = { ...FROZEN_V1, rngState: 987654321 };
+const FROZEN_V2_LATE = { ...FROZEN_V2_EARLY, seed: 42 };
 
 describe('save/load roundtrip', () => {
   it('restores a saved run', () => {
@@ -57,23 +119,120 @@ describe('save/load roundtrip', () => {
     expect(hasSave()).toBe(false);
     expect(loadGame()).toBeNull();
   });
+
+  it('keeps unknown fields from a same-version newer build', () => {
+    // A newer patch added a field without bumping the version: the
+    // save must load (and later resave) without stripping it.
+    store.set(
+      SAVE_KEY,
+      JSON.stringify({
+        version: 3,
+        savedAt: '',
+        state: { ...midRun, futureField: 'keep-me' },
+      }),
+    );
+    const loaded = loadGame() as (State & { futureField?: string }) | null;
+    expect(loaded?.futureField).toBe('keep-me');
+  });
+});
+
+describe('migrations', () => {
+  it('migrates a late-v2 save: assets gain previousPrice, run resumes', () => {
+    store.set(
+      SAVE_KEY,
+      JSON.stringify({ version: 2, savedAt: '', state: FROZEN_V2_LATE }),
+    );
+    const loaded = loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.cash).toBe(777);
+    expect(loaded?.currentDay).toBe(9);
+    // engine identity survives untouched
+    expect(loaded?.seed).toBe(42);
+    expect(loaded?.rngState).toBe(987654321);
+    // every asset gets the "no yesterday" sentinel — deltas stay
+    // hidden until the next roll, like day 1 of a fresh run
+    for (const asset of Object.values(loaded!.assets)) {
+      expect(asset.previousPrice).toBe(0);
+    }
+  });
+
+  it('migrates an early-v2 save (rngState but no seed — dee581f era)', () => {
+    // SAVE_VERSION 2 spans two shapes: `seed` landed mid-version
+    // without a bump. These saves are real runs and must migrate.
+    store.set(
+      SAVE_KEY,
+      JSON.stringify({ version: 2, savedAt: '', state: FROZEN_V2_EARLY }),
+    );
+    const loaded = loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.rngState).toBe(987654321);
+    // pre-seed run: gets the "unknown" sentinel the UI hides
+    expect(loaded?.seed).toBe(0);
+  });
+
+  it('migrates a v1 save: engine fields derived, run resumes', () => {
+    store.set(
+      SAVE_KEY,
+      JSON.stringify({ version: 1, savedAt: '', state: FROZEN_V1 }),
+    );
+    const loaded = loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.cash).toBe(777);
+    // v1 runs predate seeds: 0 is the "unknown" sentinel the UI hides
+    expect(loaded?.seed).toBe(0);
+    // a real, nonzero rng state so ADVANCE_DAY can roll prices
+    expect(typeof loaded?.rngState).toBe('number');
+    expect(loaded?.rngState).not.toBe(0);
+    for (const asset of Object.values(loaded!.assets)) {
+      expect(asset.previousPrice).toBe(0);
+    }
+  });
+
+  it('migration is pure: the same save migrates identically', () => {
+    const file = JSON.stringify({
+      version: 1,
+      savedAt: '',
+      state: FROZEN_V1,
+    });
+    store.set(SAVE_KEY, file);
+    const first = loadGame();
+    store.set(SAVE_KEY, file);
+    const second = loadGame();
+    expect(first).toEqual(second);
+  });
 });
 
 describe('save validation', () => {
-  it('rejects saves from other versions', () => {
+  it('rejects saves from an unknown future version', () => {
+    // A newer build's save is left for that build to read — an older
+    // build must not guess at a shape it has never seen.
     store.set(
       SAVE_KEY,
-      JSON.stringify({ version: 1, savedAt: '', state: midRun }),
+      JSON.stringify({ version: 99, savedAt: '', state: midRun }),
     );
     expect(loadGame()).toBeNull();
     expect(hasSave()).toBe(false);
   });
 
-  it('rejects saves missing engine fields', () => {
-    const { rngState: _rngState, ...withoutRng } = midRun;
+  it('rejects saves missing engine fields at their version', () => {
+    // rngState existed from the first moment of v2 — a v2 save
+    // without it is corrupt, not old
+    const { rngState: _rngState, ...withoutRng } = FROZEN_V2_EARLY;
     store.set(
       SAVE_KEY,
       JSON.stringify({ version: 2, savedAt: '', state: withoutRng }),
+    );
+    expect(loadGame()).toBeNull();
+  });
+
+  it('rejects saves with mistyped fields', () => {
+    store.set(
+      SAVE_KEY,
+      JSON.stringify({
+        version: 3,
+        savedAt: '',
+        state: { ...midRun, cash: 'all of it' },
+      }),
     );
     expect(loadGame()).toBeNull();
   });

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -1,53 +1,44 @@
 import { State } from '../types';
 import { initialState } from './initialState';
+import {
+  CURRENT_SAVE_VERSION,
+  migrateAndValidate,
+} from './saveSchema';
 
 const SAVE_KEY = 'cryptoFrenzySave';
-// Bump when the State shape changes incompatibly — old saves are discarded.
-// v2: engine refactor added rngState (deterministic PRNG).
-// v3: assets gained previousPrice (day-over-day delta display).
-const SAVE_VERSION = 3;
-
-type SaveFile = {
-  version: number;
-  savedAt: string;
-  state: State;
-};
 
 const isBrowser = () => typeof window !== 'undefined';
 
-const readSaveFile = (): SaveFile | null => {
+/**
+ * Read + migrate + validate the save. Old-version saves are walked
+ * forward through lib/state/saveSchema.ts migrations instead of being
+ * discarded (Phase 2; resolves the PR #34 review note) — only corrupt
+ * data or saves from an unknown FUTURE version return null.
+ */
+const readValidState = (): State | null => {
   if (!isBrowser()) return null;
   try {
     const raw = localStorage.getItem(SAVE_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as SaveFile;
-    if (parsed?.version !== SAVE_VERSION) return null;
-    const saved = parsed.state;
-    if (
-      typeof saved?.currentDay !== 'number' ||
-      typeof saved?.days !== 'number' ||
-      typeof saved?.rngState !== 'number' ||
-      !saved.assets ||
-      !saved.wallet
-    ) {
-      return null;
-    }
-    return parsed;
+    return migrateAndValidate(JSON.parse(raw));
   } catch {
     return null;
   }
 };
 
-export const hasSave = (): boolean => readSaveFile() !== null;
+export const hasSave = (): boolean => readValidState() !== null;
 
 export const loadGame = (): State | null => {
-  const file = readSaveFile();
-  if (!file) return null;
-  // Spread over initialState so fields added in newer builds get defaults.
-  // A restored run is always mid-run: modal closed, no game-over summary.
+  const saved = readValidState();
+  if (!saved) return null;
+  // Spread over initialState so SCHEMA-OPTIONAL fields added at the
+  // same save version pick up defaults. A field the schema requires
+  // needs a version bump + migration instead — see the recipe in
+  // saveSchema.ts. A restored run is always mid-run: modal closed,
+  // no game-over summary.
   return {
     ...initialState,
-    ...file.state,
+    ...saved,
     modalOpen: false,
     gameOver: null,
   };
@@ -56,8 +47,8 @@ export const loadGame = (): State | null => {
 export const saveGame = (state: State): void => {
   if (!isBrowser()) return;
   try {
-    const file: SaveFile = {
-      version: SAVE_VERSION,
+    const file = {
+      version: CURRENT_SAVE_VERSION,
       savedAt: new Date().toISOString(),
       state,
     };

--- a/lib/state/saveSchema.ts
+++ b/lib/state/saveSchema.ts
@@ -1,0 +1,200 @@
+import { z } from 'zod';
+import { State } from '../types';
+import { seedRng } from '../engine/rng';
+
+/**
+ * Save-file schema + forward migrations (Phase 2, PR #34 review).
+ *
+ * Before this, SAVE_VERSION was bump-and-discard: any shape change
+ * threw away every player's mid-run save. Now a save from any older
+ * version is migrated forward one step at a time (1→2→2→3→…) and then
+ * validated against the real schema — only genuinely corrupt data is
+ * discarded. When the State shape changes next, follow the recipe:
+ *
+ *   1. Bump CURRENT_SAVE_VERSION.
+ *   2. Add ONE migration entry for the previous version.
+ *   3. Add the new field to StateSchema and a frozen fixture test.
+ *
+ * NEVER add a required field to StateSchema without a version bump:
+ * same-version saves in the wild won't have it, validation would
+ * reject them, and every live run would be wiped — exactly what
+ * happened inside v2 when `seed` landed without a bump (see
+ * migration 2). A field added same-version must be `.optional()`
+ * here, with its default supplied by loadGame's initialState spread.
+ *
+ * Loose objects on purpose: a save written by a slightly newer build
+ * at the same version (extra fields, no bump) must survive load +
+ * resave instead of being stripped or rejected.
+ */
+
+export const CURRENT_SAVE_VERSION = 3;
+
+const finite = z.number().finite();
+
+const AssetSchema = z.looseObject({
+  name: z.string(),
+  symbol: z.string(),
+  wallet: finite,
+  active: z.boolean(),
+  averageCost: finite,
+  totalCost: finite,
+  range: z.looseObject({
+    low: z.array(finite),
+    mid: z.array(finite),
+    high: z.array(finite),
+    moon: z.array(finite),
+  }),
+  price: finite,
+  previousPrice: finite,
+});
+
+const WalletSchema = z.looseObject({
+  amount: finite,
+  capacity: finite,
+  level: finite,
+  expansionCost: finite,
+});
+
+const RunStatsSchema = z.looseObject({
+  peakNetWorth: finite,
+  totalTrades: finite,
+  bestTradeProfit: finite,
+});
+
+const GameOverSchema = z.looseObject({
+  score: finite,
+  newHighScore: z.boolean(),
+});
+
+export const StateSchema = z.looseObject({
+  days: finite,
+  currentDay: finite,
+  cash: finite,
+  debt: finite,
+  interestRate: finite,
+  log: z.array(z.string()),
+  highScore: finite.nullable().optional(),
+  modalOpen: z.boolean(),
+  // .default(null): zod 4 infers bare .nullable() properties as
+  // optional, which the compile-time guard below rejects against
+  // State's required `gameOver`. The default is also the truth —
+  // loadGame forces gameOver to null on restore regardless.
+  gameOver: GameOverSchema.nullable().default(null),
+  stats: RunStatsSchema,
+  seed: finite,
+  rngState: finite,
+  lowRangePriceChance: finite,
+  highRangePriceChance: finite,
+  mode: z.enum(['Easy', 'Hard', 'Normal', 'Test']),
+  assets: z.record(z.string(), AssetSchema),
+  wallet: WalletSchema,
+});
+
+export const SaveFileSchema = z.looseObject({
+  version: z.number().int().min(1),
+  savedAt: z.string(),
+  // validated by StateSchema only AFTER migrations run
+  state: z.unknown(),
+});
+
+export type SaveFile = z.infer<typeof SaveFileSchema>;
+
+/** Loose pre-migration shape — just enough structure to transform. */
+type AnyRecord = Record<string, unknown>;
+
+const isRecord = (v: unknown): v is AnyRecord =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * v1 saves predate the deterministic engine: no seed, no rngState.
+ * The run itself is fully resumable — it just never had a shareable
+ * seed. seed: 0 is the established "pre-run/unknown" sentinel (the
+ * sidebar hides the seed display for 0), and the rng state is derived
+ * from the save's own numbers so migration is pure: the same save
+ * always migrates to the same state.
+ */
+const deriveRngState = (state: AnyRecord): number => {
+  const day = typeof state.currentDay === 'number' ? state.currentDay : 0;
+  const cash = typeof state.cash === 'number' ? state.cash : 0;
+  const debt = typeof state.debt === 'number' ? state.debt : 0;
+  const mixed = seedRng(
+    Math.imul(day + 1, 2654435761) ^ Math.imul(cash + 1, 40503) ^ debt,
+  );
+  return mixed === 0 ? 1 : mixed;
+};
+
+/**
+ * Migrations keyed by the version they migrate FROM. Each returns the
+ * state shaped as the NEXT version expects. Pure functions of the
+ * save — no Date, no Math.random — so a save migrates identically
+ * every time it's loaded.
+ */
+const migrations: Record<number, (state: unknown) => unknown> = {
+  // v1 → v2: engine refactor introduced seed + rngState.
+  1: (state) => {
+    if (!isRecord(state)) return state;
+    return {
+      ...state,
+      seed: typeof state.seed === 'number' ? state.seed : 0,
+      rngState:
+        typeof state.rngState === 'number'
+          ? state.rngState
+          : deriveRngState(state),
+    };
+  },
+  // v2 → v3: assets gained previousPrice (day-over-day deltas).
+  // 0 is the established "no yesterday" sentinel — deltas stay hidden
+  // until the next roll, exactly like day 1 of a fresh run.
+  //
+  // seed is defaulted here too: SAVE_VERSION 2 spans two shapes in
+  // the wild — the engine refactor (dee581f) added rngState, and the
+  // seed UI (PR #35) added `seed` later WITHOUT a version bump. An
+  // early-v2 save is a real run with a real rngState that simply
+  // predates shareable seeds, so it gets the same "unknown" sentinel
+  // as v1.
+  2: (state) => {
+    if (!isRecord(state) || !isRecord(state.assets)) return state;
+    const assets: AnyRecord = {};
+    for (const [key, asset] of Object.entries(state.assets)) {
+      assets[key] = isRecord(asset)
+        ? { previousPrice: 0, ...asset }
+        : asset;
+    }
+    return {
+      ...state,
+      assets,
+      seed: typeof state.seed === 'number' ? state.seed : 0,
+    };
+  },
+};
+
+/**
+ * Walk a save forward to CURRENT_SAVE_VERSION and validate it.
+ * Returns the validated State, or null when the save is corrupt, from
+ * an unknown future version (a newer build's save is left for that
+ * build to read — never mangled by an older one), or missing a
+ * migration step.
+ */
+export const migrateAndValidate = (file: unknown): State | null => {
+  const envelope = SaveFileSchema.safeParse(file);
+  if (!envelope.success) return null;
+
+  let { version } = envelope.data;
+  let state: unknown = envelope.data.state;
+  if (version > CURRENT_SAVE_VERSION) return null;
+
+  while (version < CURRENT_SAVE_VERSION) {
+    const migrate = migrations[version];
+    if (!migrate) return null;
+    state = migrate(state);
+    version += 1;
+  }
+
+  const parsed = StateSchema.safeParse(state);
+  // No cast: returning parsed.data against the State | null signature
+  // IS the compile-time drift guard — if a required State field is
+  // ever missing from StateSchema, this return stops compiling, so
+  // the schema can't silently fall behind the type. (The reverse —
+  // schema stricter than State — fails loudly in the fixture tests.)
+  return parsed.success ? parsed.data : null;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "^7.18.1",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.2",
@@ -11091,7 +11092,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -18051,8 +18051,7 @@
     "zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     },
     "zod-validation-error": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^7.18.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.2",

--- a/pages/Game.tsx
+++ b/pages/Game.tsx
@@ -48,6 +48,13 @@ export default function Game() {
     const saved = loadGame();
     if (seedParam === null) return saved ?? fresh;
     const urlSeed = Number(seedParam) >>> 0;
+    // 0 is never a real seed: share links always carry a nonzero
+    // uint32, and 0 is the "unknown seed" sentinel stamped on
+    // migrated pre-seed saves. A ?seed= that coerces to 0 (empty,
+    // garbage, wrap-around) is a mangled link, not intent — treat it
+    // like no param rather than matching the sentinel or torching a
+    // resumable run.
+    if (urlSeed === 0) return saved ?? fresh;
     return saved && saved.seed === urlSeed ? saved : fresh;
   });
 


### PR DESCRIPTION
## Phase 2 — save-file schema + migrations

Resolves the PR #34 review note: saves are validated against a real zod schema and **older versions migrate forward** instead of being discarded. Landing now because the PWA just shipped — installed players are exactly the ones whose mid-run saves shouldn't evaporate on the next deploy.

### How it works
- **`lib/state/saveSchema.ts`** — zod schemas (loose objects, so unknown fields from a same-version newer build survive load + resave) and a migration registry keyed by from-version, walked stepwise to `CURRENT_SAVE_VERSION`:
  - **v1 → v2** (pre-engine saves): `seed: 0` — the established "unknown" sentinel the UI already hides — plus a *pure* derived `rngState` (same save always migrates identically), so the run resumes and rolls prices.
  - **v2 → v3**: assets gain `previousPrice: 0` — the "no yesterday" sentinel; deltas stay hidden until the next roll, like day 1 of a fresh run.
- **Future-version saves load as null** — an old build (SW rollback, deploy rollback) never guesses at a newer save's shape.
- **Compile-time drift guard**: `migrateAndValidate` returns `parsed.data` *uncast* against `State | null` — if a required `State` field is ever missing from the schema, the file stops compiling. This guard caught its first bug before the first commit (zod 4 infers `.nullable()` properties as optional).
- **`?seed=` hardening**: URLs that coerce to 0 (empty, garbage, uint32 wrap) now read as "no seed" — they can't false-match the migrated-save sentinel or torch a resumable run on a mangled link.

### What the adversarial review caught (3 lenses, 14 agents, pre-push)
- **SAVE_VERSION 2 spans two shapes in the wild**: the engine refactor (dee581f) added `rngState`, but `seed` landed later in PR #35 *without a version bump* — so genuine early-v2 saves have no `seed` and were validating to null, the exact discard this PR exists to eliminate. Migration 2 now defaults it, and the schema header documents the standing rule: *a new required State field means a version bump + one migration entry; same-version additions must be schema-optional.*
- Test fixtures were derived from current `initialState` and silently tracked the present (which is how the early-v2 shape hid) — replaced with **frozen literals transcribed from git history**.
- A stale comment promising the old lenient spread behavior.

### Verification
62 unit / 30 E2E green. Live-verified in the browser: planted genuine v1, early-v2 (no seed), and late-v2 saves — each resumes mid-run with cash/days intact, re-persists as v3, and advances days on its preserved rngState with deltas appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)